### PR TITLE
:sparkles: Add Netlify logo on all builds

### DIFF
--- a/build/docsify/__snapshots__/write-homepage.test.js.snap
+++ b/build/docsify/__snapshots__/write-homepage.test.js.snap
@@ -10,6 +10,10 @@ Please update [this file](https://github.com/yannbertrand/macos-defaults/blob/ma
 
 ## ❤️ I like this website, how can I build the same?
 Thank you! I built it using [docsify](https://docsify.js.org/). Take a look at [my report](https://github.com/yannbertrand/macos-defaults/tree/master/build/docsify#readme) if you want to use it.
+
+<a href=\\"https://www.netlify.com\\">
+  <img src=\\"https://www.netlify.com/img/global/badges/netlify-light.svg\\" alt=\\"Deploys by Netlify\\" />
+</a>
 "
 `;
 
@@ -25,6 +29,10 @@ Please update [this file](https://github.com/yannbertrand/macos-defaults/blob/ma
 
 ## ❤️ I like this website, how can I build the same?
 Thank you! I built it using [docsify](https://docsify.js.org/). Take a look at [my report](https://github.com/yannbertrand/macos-defaults/tree/master/build/docsify#readme) if you want to use it.
+
+<a href=\\"https://www.netlify.com\\">
+  <img src=\\"https://www.netlify.com/img/global/badges/netlify-light.svg\\" alt=\\"Deploys by Netlify\\" />
+</a>
 "
 `;
 
@@ -41,6 +49,10 @@ Please update [this file](https://github.com/yannbertrand/macos-defaults/blob/ma
 
 ## ❤️ I like this website, how can I build the same?
 Thank you! I built it using [docsify](https://docsify.js.org/). Take a look at [my report](https://github.com/yannbertrand/macos-defaults/tree/master/build/docsify#readme) if you want to use it.
+
+<a href=\\"https://www.netlify.com\\">
+  <img src=\\"https://www.netlify.com/img/global/badges/netlify-light.svg\\" alt=\\"Deploys by Netlify\\" />
+</a>
 "
 `;
 
@@ -58,6 +70,10 @@ Please update [this file](https://github.com/yannbertrand/macos-defaults/blob/ma
 
 ## ❤️ I like this website, how can I build the same?
 Thank you! I built it using [docsify](https://docsify.js.org/). Take a look at [my report](https://github.com/yannbertrand/macos-defaults/tree/master/build/docsify#readme) if you want to use it.
+
+<a href=\\"https://www.netlify.com\\">
+  <img src=\\"https://www.netlify.com/img/global/badges/netlify-light.svg\\" alt=\\"Deploys by Netlify\\" />
+</a>
 "
 `;
 
@@ -77,5 +93,9 @@ Please update [this file](https://github.com/yannbertrand/macos-defaults/blob/ma
 
 ## ❤️ I like this website, how can I build the same?
 Thank you! I built it using [docsify](https://docsify.js.org/). Take a look at [my report](https://github.com/yannbertrand/macos-defaults/tree/master/build/docsify#readme) if you want to use it.
+
+<a href=\\"https://www.netlify.com\\">
+  <img src=\\"https://www.netlify.com/img/global/badges/netlify-light.svg\\" alt=\\"Deploys by Netlify\\" />
+</a>
 "
 `;

--- a/build/docsify/templates/fr/home.md.handlebars
+++ b/build/docsify/templates/fr/home.md.handlebars
@@ -14,3 +14,7 @@ Mettez à jour [ce fichier](https://github.com/yannbertrand/macos-defaults/blob/
 
 ## ❤️ J'adore ce site, comment faire le même ?
 Merci ! Il a été construit grâce à [VuePress](https://vuepress.vuejs.org/). Si vous parlez anglais, jetez un oeil à [mon avis](https://github.com/yannbertrand/macos-defaults/tree/master/build/vuepress#readme) si vous voulez utiliser l'outil.
+
+<a href="https://www.netlify.com">
+  <img src="https://www.netlify.com/img/global/badges/netlify-light.svg" alt="Déployé par Netlify" />
+</a>

--- a/build/docsify/templates/home.md.handlebars
+++ b/build/docsify/templates/home.md.handlebars
@@ -14,3 +14,7 @@ Please update [this file](https://github.com/yannbertrand/macos-defaults/blob/ma
 
 ## ❤️ I like this website, how can I build the same?
 Thank you! I built it using [docsify](https://docsify.js.org/). Take a look at [my report](https://github.com/yannbertrand/macos-defaults/tree/master/build/docsify#readme) if you want to use it.
+
+<a href="https://www.netlify.com">
+  <img src="https://www.netlify.com/img/global/badges/netlify-light.svg" alt="Deploys by Netlify" />
+</a>

--- a/build/docusaurus/__snapshots__/write-homepage.test.js.snap
+++ b/build/docusaurus/__snapshots__/write-homepage.test.js.snap
@@ -15,6 +15,10 @@ Please update [this file](https://github.com/yannbertrand/macos-defaults/blob/ma
 
 ## ❤️ I like this website, how can I build the same?
 Thank you! I built it using [Docusaurus](https://docusaurus.io/). Take a look at [my report](https://github.com/yannbertrand/macos-defaults/tree/master/build/docusaurus#readme) if you want to use it.
+
+<a href=\\"https://www.netlify.com\\">
+  <img src=\\"https://www.netlify.com/img/global/badges/netlify-light.svg\\" alt=\\"Deploys by Netlify\\" />
+</a>
 "
 `;
 
@@ -35,6 +39,10 @@ Please update [this file](https://github.com/yannbertrand/macos-defaults/blob/ma
 
 ## ❤️ I like this website, how can I build the same?
 Thank you! I built it using [Docusaurus](https://docusaurus.io/). Take a look at [my report](https://github.com/yannbertrand/macos-defaults/tree/master/build/docusaurus#readme) if you want to use it.
+
+<a href=\\"https://www.netlify.com\\">
+  <img src=\\"https://www.netlify.com/img/global/badges/netlify-light.svg\\" alt=\\"Deploys by Netlify\\" />
+</a>
 "
 `;
 
@@ -56,6 +64,10 @@ Please update [this file](https://github.com/yannbertrand/macos-defaults/blob/ma
 
 ## ❤️ I like this website, how can I build the same?
 Thank you! I built it using [Docusaurus](https://docusaurus.io/). Take a look at [my report](https://github.com/yannbertrand/macos-defaults/tree/master/build/docusaurus#readme) if you want to use it.
+
+<a href=\\"https://www.netlify.com\\">
+  <img src=\\"https://www.netlify.com/img/global/badges/netlify-light.svg\\" alt=\\"Deploys by Netlify\\" />
+</a>
 "
 `;
 
@@ -78,6 +90,10 @@ Please update [this file](https://github.com/yannbertrand/macos-defaults/blob/ma
 
 ## ❤️ I like this website, how can I build the same?
 Thank you! I built it using [Docusaurus](https://docusaurus.io/). Take a look at [my report](https://github.com/yannbertrand/macos-defaults/tree/master/build/docusaurus#readme) if you want to use it.
+
+<a href=\\"https://www.netlify.com\\">
+  <img src=\\"https://www.netlify.com/img/global/badges/netlify-light.svg\\" alt=\\"Deploys by Netlify\\" />
+</a>
 "
 `;
 
@@ -102,5 +118,9 @@ Please update [this file](https://github.com/yannbertrand/macos-defaults/blob/ma
 
 ## ❤️ I like this website, how can I build the same?
 Thank you! I built it using [Docusaurus](https://docusaurus.io/). Take a look at [my report](https://github.com/yannbertrand/macos-defaults/tree/master/build/docusaurus#readme) if you want to use it.
+
+<a href=\\"https://www.netlify.com\\">
+  <img src=\\"https://www.netlify.com/img/global/badges/netlify-light.svg\\" alt=\\"Deploys by Netlify\\" />
+</a>
 "
 `;

--- a/build/docusaurus/readme.md
+++ b/build/docusaurus/readme.md
@@ -49,7 +49,7 @@ yarn install
 This will build the [defaults.yml file](../../defaults.yml) and run a Docusaurus server on http://localhost:3000/docs/. Sources of the website are available in the `dist` folder.
 
 ```sh
-yarn build
+yarn start
 ```
 
 ### 🚧 Run unit tests

--- a/build/docusaurus/templates/home.md.handlebars
+++ b/build/docusaurus/templates/home.md.handlebars
@@ -19,3 +19,7 @@ Please update [this file](https://github.com/yannbertrand/macos-defaults/blob/ma
 
 ## ❤️ I like this website, how can I build the same?
 Thank you! I built it using [Docusaurus](https://docusaurus.io/). Take a look at [my report](https://github.com/yannbertrand/macos-defaults/tree/master/build/docusaurus#readme) if you want to use it.
+
+<a href="https://www.netlify.com">
+  <img src="https://www.netlify.com/img/global/badges/netlify-light.svg" alt="Deploys by Netlify" />
+</a>

--- a/build/github/__snapshots__/write-homepage.test.js.snap
+++ b/build/github/__snapshots__/write-homepage.test.js.snap
@@ -10,6 +10,10 @@ Please update [this file](https://github.com/yannbertrand/macos-defaults/blob/ma
 
 ## ❤️ I like this website, how can I build the same?
 Thank you! I built it from scratch. Take a look at [my report](https://github.com/yannbertrand/macos-defaults/tree/master/build/github#readme) if you want to do the same.
+
+<a href=\\"https://www.netlify.com\\">
+  <img src=\\"https://www.netlify.com/img/global/badges/netlify-light.svg\\" alt=\\"Deploys by Netlify\\" />
+</a>
 "
 `;
 
@@ -25,6 +29,10 @@ Please update [this file](https://github.com/yannbertrand/macos-defaults/blob/ma
 
 ## ❤️ I like this website, how can I build the same?
 Thank you! I built it from scratch. Take a look at [my report](https://github.com/yannbertrand/macos-defaults/tree/master/build/github#readme) if you want to do the same.
+
+<a href=\\"https://www.netlify.com\\">
+  <img src=\\"https://www.netlify.com/img/global/badges/netlify-light.svg\\" alt=\\"Deploys by Netlify\\" />
+</a>
 "
 `;
 
@@ -41,6 +49,10 @@ Please update [this file](https://github.com/yannbertrand/macos-defaults/blob/ma
 
 ## ❤️ I like this website, how can I build the same?
 Thank you! I built it from scratch. Take a look at [my report](https://github.com/yannbertrand/macos-defaults/tree/master/build/github#readme) if you want to do the same.
+
+<a href=\\"https://www.netlify.com\\">
+  <img src=\\"https://www.netlify.com/img/global/badges/netlify-light.svg\\" alt=\\"Deploys by Netlify\\" />
+</a>
 "
 `;
 
@@ -58,6 +70,10 @@ Please update [this file](https://github.com/yannbertrand/macos-defaults/blob/ma
 
 ## ❤️ I like this website, how can I build the same?
 Thank you! I built it from scratch. Take a look at [my report](https://github.com/yannbertrand/macos-defaults/tree/master/build/github#readme) if you want to do the same.
+
+<a href=\\"https://www.netlify.com\\">
+  <img src=\\"https://www.netlify.com/img/global/badges/netlify-light.svg\\" alt=\\"Deploys by Netlify\\" />
+</a>
 "
 `;
 
@@ -77,5 +93,9 @@ Please update [this file](https://github.com/yannbertrand/macos-defaults/blob/ma
 
 ## ❤️ I like this website, how can I build the same?
 Thank you! I built it from scratch. Take a look at [my report](https://github.com/yannbertrand/macos-defaults/tree/master/build/github#readme) if you want to do the same.
+
+<a href=\\"https://www.netlify.com\\">
+  <img src=\\"https://www.netlify.com/img/global/badges/netlify-light.svg\\" alt=\\"Deploys by Netlify\\" />
+</a>
 "
 `;

--- a/build/github/templates/home.md.handlebars
+++ b/build/github/templates/home.md.handlebars
@@ -14,3 +14,7 @@ Please update [this file](https://github.com/yannbertrand/macos-defaults/blob/ma
 
 ## ❤️ I like this website, how can I build the same?
 Thank you! I built it from scratch. Take a look at [my report](https://github.com/yannbertrand/macos-defaults/tree/master/build/github#readme) if you want to do the same.
+
+<a href="https://www.netlify.com">
+  <img src="https://www.netlify.com/img/global/badges/netlify-light.svg" alt="Deploys by Netlify" />
+</a>

--- a/build/production/templates/fr/home.md.handlebars
+++ b/build/production/templates/fr/home.md.handlebars
@@ -78,3 +78,7 @@ Mettez à jour [ce fichier](https://github.com/yannbertrand/macos-defaults/blob/
 
 ## ❤️ J'adore ce site, comment faire le même ?
 Merci ! Il a été construit grâce à [VuePress](https://vuepress.vuejs.org/). Jetez un coup d'oeil à [mon avis](https://github.com/yannbertrand/macos-defaults/tree/master/build/vuepress#readme) si vous souhaitez utiliser la même techno.
+
+<a href="https://www.netlify.com">
+  <img src="https://www.netlify.com/img/global/badges/netlify-light.svg" alt="Déployé par Netlify" />
+</a>

--- a/build/production/templates/home.md.handlebars
+++ b/build/production/templates/home.md.handlebars
@@ -78,3 +78,7 @@ Please update [this file](https://github.com/yannbertrand/macos-defaults/blob/ma
 
 ## ❤️ I like this website, how can I build the same?
 Thank you! I built it using [VuePress](https://vuepress.vuejs.org/). Take a look at [my report](https://github.com/yannbertrand/macos-defaults/tree/master/build/vuepress#readme) if you want to use it.
+
+<a href="https://www.netlify.com">
+  <img src="https://www.netlify.com/img/global/badges/netlify-light.svg" alt="Deploys by Netlify" />
+</a>

--- a/build/vuepress/__snapshots__/write-homepage.test.js.snap
+++ b/build/vuepress/__snapshots__/write-homepage.test.js.snap
@@ -13,6 +13,10 @@ Please update [this file](https://github.com/yannbertrand/macos-defaults/blob/ma
 
 ## ❤️ I like this website, how can I build the same?
 Thank you! I built it using [VuePress](https://vuepress.vuejs.org/). Take a look at [my report](https://github.com/yannbertrand/macos-defaults/tree/master/build/vuepress#readme) if you want to use it.
+
+<a href=\\"https://www.netlify.com\\">
+  <img src=\\"https://www.netlify.com/img/global/badges/netlify-light.svg\\" alt=\\"Deploys by Netlify\\" />
+</a>
 "
 `;
 
@@ -31,6 +35,10 @@ Please update [this file](https://github.com/yannbertrand/macos-defaults/blob/ma
 
 ## ❤️ I like this website, how can I build the same?
 Thank you! I built it using [VuePress](https://vuepress.vuejs.org/). Take a look at [my report](https://github.com/yannbertrand/macos-defaults/tree/master/build/vuepress#readme) if you want to use it.
+
+<a href=\\"https://www.netlify.com\\">
+  <img src=\\"https://www.netlify.com/img/global/badges/netlify-light.svg\\" alt=\\"Deploys by Netlify\\" />
+</a>
 "
 `;
 
@@ -50,6 +58,10 @@ Please update [this file](https://github.com/yannbertrand/macos-defaults/blob/ma
 
 ## ❤️ I like this website, how can I build the same?
 Thank you! I built it using [VuePress](https://vuepress.vuejs.org/). Take a look at [my report](https://github.com/yannbertrand/macos-defaults/tree/master/build/vuepress#readme) if you want to use it.
+
+<a href=\\"https://www.netlify.com\\">
+  <img src=\\"https://www.netlify.com/img/global/badges/netlify-light.svg\\" alt=\\"Deploys by Netlify\\" />
+</a>
 "
 `;
 
@@ -70,6 +82,10 @@ Please update [this file](https://github.com/yannbertrand/macos-defaults/blob/ma
 
 ## ❤️ I like this website, how can I build the same?
 Thank you! I built it using [VuePress](https://vuepress.vuejs.org/). Take a look at [my report](https://github.com/yannbertrand/macos-defaults/tree/master/build/vuepress#readme) if you want to use it.
+
+<a href=\\"https://www.netlify.com\\">
+  <img src=\\"https://www.netlify.com/img/global/badges/netlify-light.svg\\" alt=\\"Deploys by Netlify\\" />
+</a>
 "
 `;
 
@@ -92,5 +108,9 @@ Please update [this file](https://github.com/yannbertrand/macos-defaults/blob/ma
 
 ## ❤️ I like this website, how can I build the same?
 Thank you! I built it using [VuePress](https://vuepress.vuejs.org/). Take a look at [my report](https://github.com/yannbertrand/macos-defaults/tree/master/build/vuepress#readme) if you want to use it.
+
+<a href=\\"https://www.netlify.com\\">
+  <img src=\\"https://www.netlify.com/img/global/badges/netlify-light.svg\\" alt=\\"Deploys by Netlify\\" />
+</a>
 "
 `;

--- a/build/vuepress/templates/fr/home.md.handlebars
+++ b/build/vuepress/templates/fr/home.md.handlebars
@@ -17,3 +17,7 @@ Mettez à jour [ce fichier](https://github.com/yannbertrand/macos-defaults/blob/
 
 ## ❤️ J'adore ce site, comment faire le même ?
 Merci ! Il a été construit grâce à [VuePress](https://vuepress.vuejs.org/). Si vous parlez anglais, jetez un oeil à [mon avis](https://github.com/yannbertrand/macos-defaults/tree/master/build/vuepress#readme) si vous voulez utiliser l'outil.
+
+<a href="https://www.netlify.com">
+  <img src="https://www.netlify.com/img/global/badges/netlify-light.svg" alt="Déployé par Netlify" />
+</a>

--- a/build/vuepress/templates/home.md.handlebars
+++ b/build/vuepress/templates/home.md.handlebars
@@ -17,3 +17,7 @@ Please update [this file](https://github.com/yannbertrand/macos-defaults/blob/ma
 
 ## ❤️ I like this website, how can I build the same?
 Thank you! I built it using [VuePress](https://vuepress.vuejs.org/). Take a look at [my report](https://github.com/yannbertrand/macos-defaults/tree/master/build/vuepress#readme) if you want to use it.
+
+<a href="https://www.netlify.com">
+  <img src="https://www.netlify.com/img/global/badges/netlify-light.svg" alt="Deploys by Netlify" />
+</a>


### PR DESCRIPTION
I have added the "Deploys by Netlify" logo at the bottom the Homepage of each build (and each language):
- Vuepress
- Docusaurus
- Docsify
- Production
- GitHub

I also fix a typo in the README.md file of the `Production` build `README.md` file. I can make a different PR for this one if you want

> Made with GitHub Codespace ❤️ 