### PR TITLE
[feat][TimeMachine] Add command for new disk backup prompt

### DIFF
--- a/defaults.yml
+++ b/defaults.yml
@@ -498,6 +498,7 @@ categories:
             text:
               When a new disk is connected, system does not prompt to ask if you want to use it as a backup volume.
         versions: [Catalina]
+
   - folder: misc
     name: Miscellaneous
     description: All the others `defaults` that don't deserve their own category.

--- a/defaults.yml
+++ b/defaults.yml
@@ -475,6 +475,29 @@ categories:
         versions: [Catalina]
         after: killall Xcode
 
+
+  - folder: timemachine
+    name: Time Machine
+    description:
+      The Time Machine feature allows simple, regular backups of your
+      filesystem.
+    keys:
+      - key: DoNotOfferNewDisksForBackup
+        domain: com.apple.TimeMachine
+        title: Don't offer new disks for Time Machine backup.
+        description:
+          Prevent Time Machine from prompting to use newly connected storage as backup volumes.
+        param:
+          type: bool
+        examples:
+          - value: false
+            default: true
+            text:
+              When a new disk is connected, system prompts to ask if you want to use it as a backup volume.
+          - value: true
+            text:
+              When a new disk is connected, system does not prompt to ask if you want to use it as a backup volume.
+        versions: [Catalina]
   - folder: misc
     name: Miscellaneous
     description: All the others `defaults` that don't deserve their own category.

--- a/defaults.yml
+++ b/defaults.yml
@@ -484,7 +484,7 @@ categories:
     keys:
       - key: DoNotOfferNewDisksForBackup
         domain: com.apple.TimeMachine
-        title: Don't offer new disks for Time Machine backup.
+        title: Don't offer new disks for Time Machine backup
         description:
           Prevent Time Machine from prompting to use newly connected storage as backup volumes.
         param:


### PR DESCRIPTION
**Why this change was necessary**
By default, when a new disk is connected to a Mac for the first time
after it's been formatted, Time Machine asks the user if they want to
add it as a backup volume. This can be tedious for users that
frequently use and format portable hard drives for data transfer.

**What this change does**
Adds a defaults command allowing the user to disable these prompts
when a new disk is connected.

**Any side-effects?**
None.

**Additional context/notes/links**

https://www.defaults-write.com/disable-new-disks-requests-for-time-machine/
Resolves yannbertrand/macos-defaults#54