### PR TITLE
Add ShowBuildOperationDuration

### DIFF
--- a/defaults.yml
+++ b/defaults.yml
@@ -474,6 +474,21 @@ categories:
             text: Add the "Router", "Interactor" and "Builder" counterpart suffixes (Useful for RIB architectures).
         versions: [Catalina]
         after: killall Xcode
+      - key: ShowBuildOperationDuration
+        domain: com.apple.dt.Xcode
+        title: Show Build Durations
+        description:
+          Show build durations in the Activity Viewer in Xcode's toolbar at the top of the workspace window.
+        param:
+          type: bool
+        examples:
+          - value: true
+            text: Show the build duration in the Xcode's toolbar
+          - value: false
+            default: true
+            text: Do not show the build duration in the Xcode's toolbar
+        versions: [Catalina]
+        after: killall Xcode
 
   - folder: misc
     name: Miscellaneous


### PR DESCRIPTION
This PR adds the `ShowBuildOperationDuration` default to the Xcode section. Setting this value to true will show the build duration in Xcode's toolbar.

As with #46, I didn't create a way to record a screenshot, as this would require the compilation of a project. Is there a way to manually add screenshots? E.g. the one below?

![Screen Shot 2020-10-17 at 11 06 31@2x](https://user-images.githubusercontent.com/7734806/96333293-4595fc80-1069-11eb-9aa5-4024ce266993.png)
