### PR TITLE
Improved markdown support

### DIFF
--- a/build/production/__snapshots__/write-categories.test.js.snap
+++ b/build/production/__snapshots__/write-categories.test.js.snap
@@ -7,9 +7,9 @@ meta:
   - property: \\"og:title\\"
     content: macOS defaults > Category
   - name: \\"description\\"
-    content: \\"Category description.\\"
+    content: \\"This is a description of the category. It can contain \\\\\\"quotes\\\\\\" and markdown.\\\\n\\\\n- a list item\\"
   - property: \\"og:description\\"
-    content: \\"Category description.\\"
+    content: \\"This is a description of the category. It can contain \\\\\\"quotes\\\\\\" and markdown.\\\\n\\\\n- a list item\\"
   - property: \\"twitter:card\\"
     content: \\"summary\\"
   - property: \\"twitter:image\\"
@@ -24,8 +24,10 @@ meta:
   width=\\"740\\" height=\\"80\\" style=\\"height: auto\\"
 />
 
+This is a description of the category. It can contain \\"quotes\\" and markdown.
 
-Category description.
+- a list item
+
 ## Keys
 
 "
@@ -50,8 +52,8 @@ meta:
 ---
 # Category
 
-
 Category description.
+
 ## Keys
 
 - [Page](./page.html)
@@ -77,8 +79,8 @@ meta:
 ---
 # Category
 
-
 Category description.
+
 ## Keys
 
 - [Page 1](./page1.html)
@@ -105,8 +107,8 @@ meta:
 ---
 # Category 1
 
-
 Category 1 description.
+
 ## Keys
 
 - [Page](./page.html)
@@ -132,8 +134,8 @@ meta:
 ---
 # Category 2
 
-
 Category 2 description.
+
 ## Keys
 
 - [Page](./page.html)

--- a/build/production/__snapshots__/write-categories.test.js.snap
+++ b/build/production/__snapshots__/write-categories.test.js.snap
@@ -7,9 +7,9 @@ meta:
   - property: \\"og:title\\"
     content: macOS defaults > Category
   - name: \\"description\\"
-    content: Category description.
+    content: \\"Category description.\\"
   - property: \\"og:description\\"
-    content: Category description.
+    content: \\"Category description.\\"
   - property: \\"twitter:card\\"
     content: \\"summary\\"
   - property: \\"twitter:image\\"
@@ -24,7 +24,9 @@ meta:
   width=\\"740\\" height=\\"80\\" style=\\"height: auto\\"
 />
 
+
 Category description.
+## Keys
 
 "
 `;
@@ -36,9 +38,9 @@ meta:
   - property: \\"og:title\\"
     content: macOS defaults > Category
   - name: \\"description\\"
-    content: Category description.
+    content: \\"Category description.\\"
   - property: \\"og:description\\"
-    content: Category description.
+    content: \\"Category description.\\"
   - property: \\"twitter:card\\"
     content: \\"summary\\"
   - property: \\"twitter:image\\"
@@ -48,7 +50,9 @@ meta:
 ---
 # Category
 
+
 Category description.
+## Keys
 
 - [Page](./page.html)
 "
@@ -61,9 +65,9 @@ meta:
   - property: \\"og:title\\"
     content: macOS defaults > Category
   - name: \\"description\\"
-    content: Category description.
+    content: \\"Category description.\\"
   - property: \\"og:description\\"
-    content: Category description.
+    content: \\"Category description.\\"
   - property: \\"twitter:card\\"
     content: \\"summary\\"
   - property: \\"twitter:image\\"
@@ -73,7 +77,9 @@ meta:
 ---
 # Category
 
+
 Category description.
+## Keys
 
 - [Page 1](./page1.html)
 - [Page 2](./page2.html)
@@ -87,9 +93,9 @@ meta:
   - property: \\"og:title\\"
     content: macOS defaults > Category 1
   - name: \\"description\\"
-    content: Category 1 description.
+    content: \\"Category 1 description.\\"
   - property: \\"og:description\\"
-    content: Category 1 description.
+    content: \\"Category 1 description.\\"
   - property: \\"twitter:card\\"
     content: \\"summary\\"
   - property: \\"twitter:image\\"
@@ -99,7 +105,9 @@ meta:
 ---
 # Category 1
 
+
 Category 1 description.
+## Keys
 
 - [Page](./page.html)
 "
@@ -112,9 +120,9 @@ meta:
   - property: \\"og:title\\"
     content: macOS defaults > Category 2
   - name: \\"description\\"
-    content: Category 2 description.
+    content: \\"Category 2 description.\\"
   - property: \\"og:description\\"
-    content: Category 2 description.
+    content: \\"Category 2 description.\\"
   - property: \\"twitter:card\\"
     content: \\"summary\\"
   - property: \\"twitter:image\\"
@@ -124,7 +132,9 @@ meta:
 ---
 # Category 2
 
+
 Category 2 description.
+## Keys
 
 - [Page](./page.html)
 "

--- a/build/production/__snapshots__/write-pages.test.js.snap
+++ b/build/production/__snapshots__/write-pages.test.js.snap
@@ -7,9 +7,9 @@ meta:
   - property: \\"og:title\\"
     content: macOS defaults > Category > Page
   - name: \\"description\\"
-    content: Page description.
+    content: \\"Page description.\\"
   - property: \\"og:description\\"
-    content: Page description.
+    content: \\"Page description.\\"
   - property: \\"twitter:card\\"
     content: \\"summary\\"
   - property: \\"twitter:image\\"
@@ -20,6 +20,8 @@ meta:
 # Page
 
 Page description.
+
+<!-- break lists -->
 
 - **Tested on macOS**:
   * Big Sur
@@ -66,9 +68,9 @@ meta:
   - property: \\"og:title\\"
     content: macOS defaults > Category > Page
   - name: \\"description\\"
-    content: Page description.
+    content: \\"Page description.\\"
   - property: \\"og:description\\"
-    content: Page description.
+    content: \\"Page description.\\"
   - property: \\"twitter:card\\"
     content: \\"summary\\"
   - property: \\"twitter:image\\"
@@ -79,6 +81,8 @@ meta:
 # Page
 
 Page description.
+
+<!-- break lists -->
 
 - **Tested on macOS**:
   * Big Sur
@@ -130,9 +134,9 @@ meta:
   - property: \\"og:title\\"
     content: macOS defaults > Category > Page
   - name: \\"description\\"
-    content: Page description.
+    content: \\"Page description.\\"
   - property: \\"og:description\\"
-    content: Page description.
+    content: \\"Page description.\\"
   - property: \\"twitter:card\\"
     content: \\"summary\\"
   - property: \\"twitter:image\\"
@@ -143,6 +147,8 @@ meta:
 # Page
 
 Page description.
+
+<!-- break lists -->
 
 - **Tested on macOS**:
   * Big Sur
@@ -170,9 +176,9 @@ meta:
   - property: \\"og:title\\"
     content: macOS defaults > Category > Page
   - name: \\"description\\"
-    content: Page description.
+    content: \\"Page description.\\"
   - property: \\"og:description\\"
-    content: Page description.
+    content: \\"Page description.\\"
   - property: \\"twitter:card\\"
     content: \\"summary\\"
   - property: \\"twitter:image\\"
@@ -183,6 +189,8 @@ meta:
 # Page
 
 Page description.
+
+<!-- break lists -->
 
 - **Tested on macOS**:
   * Big Sur
@@ -223,9 +231,9 @@ meta:
   - property: \\"og:title\\"
     content: macOS defaults > Category > Page
   - name: \\"description\\"
-    content: Page description.
+    content: \\"Page description.\\"
   - property: \\"og:description\\"
-    content: Page description.
+    content: \\"Page description.\\"
   - property: \\"twitter:card\\"
     content: \\"summary\\"
   - property: \\"twitter:image\\"
@@ -236,6 +244,8 @@ meta:
 # Page
 
 Page description.
+
+<!-- break lists -->
 
 - **Tested on macOS**:
   * Big Sur
@@ -280,9 +290,9 @@ meta:
   - property: \\"og:title\\"
     content: macOS defaults > Category > Page
   - name: \\"description\\"
-    content: Page description.
+    content: \\"Page description.\\"
   - property: \\"og:description\\"
-    content: Page description.
+    content: \\"Page description.\\"
   - property: \\"twitter:card\\"
     content: \\"summary\\"
   - property: \\"twitter:image\\"
@@ -293,6 +303,8 @@ meta:
 # Page
 
 Page description.
+
+<!-- break lists -->
 
 - **Tested on macOS**:
   * Big Sur
@@ -333,9 +345,9 @@ meta:
   - property: \\"og:title\\"
     content: macOS defaults > Category > Page
   - name: \\"description\\"
-    content: Page description.
+    content: \\"Page description.\\"
   - property: \\"og:description\\"
-    content: Page description.
+    content: \\"Page description.\\"
   - property: \\"twitter:card\\"
     content: \\"summary\\"
   - property: \\"twitter:image\\"
@@ -346,6 +358,8 @@ meta:
 # Page
 
 Page description.
+
+<!-- break lists -->
 
 - **Tested on macOS**:
   * Big Sur
@@ -390,9 +404,9 @@ meta:
   - property: \\"og:title\\"
     content: macOS defaults > Category > Page 1
   - name: \\"description\\"
-    content: Page 1 description.
+    content: \\"Page 1 description.\\"
   - property: \\"og:description\\"
-    content: Page 1 description.
+    content: \\"Page 1 description.\\"
   - property: \\"twitter:card\\"
     content: \\"summary\\"
   - property: \\"twitter:image\\"
@@ -403,6 +417,8 @@ meta:
 # Page 1
 
 Page 1 description.
+
+<!-- break lists -->
 
 - **Tested on macOS**:
   * Big Sur
@@ -443,9 +459,9 @@ meta:
   - property: \\"og:title\\"
     content: macOS defaults > Category > Page 2
   - name: \\"description\\"
-    content: Page 2 description.
+    content: \\"Page 2 description.\\"
   - property: \\"og:description\\"
-    content: Page 2 description.
+    content: \\"Page 2 description.\\"
   - property: \\"twitter:card\\"
     content: \\"summary\\"
   - property: \\"twitter:image\\"
@@ -456,6 +472,8 @@ meta:
 # Page 2
 
 Page 2 description.
+
+<!-- break lists -->
 
 - **Tested on macOS**:
   * Big Sur
@@ -496,9 +514,9 @@ meta:
   - property: \\"og:title\\"
     content: macOS defaults > Category 1 > Page
   - name: \\"description\\"
-    content: Page description.
+    content: \\"Page description.\\"
   - property: \\"og:description\\"
-    content: Page description.
+    content: \\"Page description.\\"
   - property: \\"twitter:card\\"
     content: \\"summary\\"
   - property: \\"twitter:image\\"
@@ -509,6 +527,8 @@ meta:
 # Page
 
 Page description.
+
+<!-- break lists -->
 
 - **Tested on macOS**:
   * Big Sur
@@ -549,9 +569,9 @@ meta:
   - property: \\"og:title\\"
     content: macOS defaults > Category 2 > Page
   - name: \\"description\\"
-    content: Page description.
+    content: \\"Page description.\\"
   - property: \\"og:description\\"
-    content: Page description.
+    content: \\"Page description.\\"
   - property: \\"twitter:card\\"
     content: \\"summary\\"
   - property: \\"twitter:image\\"
@@ -562,6 +582,8 @@ meta:
 # Page
 
 Page description.
+
+<!-- break lists -->
 
 - **Tested on macOS**:
   * Big Sur

--- a/build/production/__snapshots__/write-pages.test.js.snap
+++ b/build/production/__snapshots__/write-pages.test.js.snap
@@ -290,9 +290,9 @@ meta:
   - property: \\"og:title\\"
     content: macOS defaults > Category > Page
   - name: \\"description\\"
-    content: \\"Page description.\\"
+    content: \\"This is a description of the page. It can contain \\\\\\"quotes\\\\\\" and markdown.\\\\n\\\\n- a list item\\"
   - property: \\"og:description\\"
-    content: \\"Page description.\\"
+    content: \\"This is a description of the page. It can contain \\\\\\"quotes\\\\\\" and markdown.\\\\n\\\\n- a list item\\"
   - property: \\"twitter:card\\"
     content: \\"summary\\"
   - property: \\"twitter:image\\"
@@ -302,7 +302,9 @@ meta:
 ---
 # Page
 
-Page description.
+This is a description of the page. It can contain \\"quotes\\" and markdown.
+
+- a list item
 
 <!-- break lists -->
 

--- a/build/production/build.js
+++ b/build/production/build.js
@@ -1,6 +1,7 @@
 const fs = require('fs')
 const YAML = require('yaml')
 
+require('./handlebars-helpers')
 const writeHomepage = require('./write-homepage')
 const writeCategories = require('./write-categories')
 const writePages = require('./write-pages')

--- a/build/production/handlebars-helpers.js
+++ b/build/production/handlebars-helpers.js
@@ -1,0 +1,5 @@
+const Handlebars = require('handlebars')
+
+Handlebars.registerHelper('json', (string) => {
+  return JSON.stringify(string)
+})

--- a/build/production/templates/category.md.handlebars
+++ b/build/production/templates/category.md.handlebars
@@ -4,9 +4,9 @@ meta:
   - property: "og:title"
     content: macOS defaults > {{{ name }}}
   - name: "description"
-    content: {{{ escapeDoubleQuote description }}}
+    content: {{{ json description }}}
   - property: "og:description"
-    content: {{{ escapeDoubleQuote description }}}
+    content: {{{ json description }}}
   - property: "twitter:card"
     content: "summary"
   - property: "twitter:image"
@@ -23,7 +23,9 @@ meta:
 />
 
 {{/ image }}
+
 {{{ description }}}
+## Keys
 
 {{# keys }}
 - [{{ title }}](./{{ lowerCase key }}.html)

--- a/build/production/templates/category.md.handlebars
+++ b/build/production/templates/category.md.handlebars
@@ -23,8 +23,8 @@ meta:
 />
 
 {{/ image }}
-
 {{{ description }}}
+
 ## Keys
 
 {{# keys }}

--- a/build/production/templates/fr/category.md.handlebars
+++ b/build/production/templates/fr/category.md.handlebars
@@ -4,9 +4,9 @@ meta:
   - property: "og:title"
     content: macOS defaults > {{{ name }}}
   - name: "description"
-    content: {{{ escapeDoubleQuote description }}}
+    content: {{{ json description }}}
   - property: "og:description"
-    content: {{{ escapeDoubleQuote description }}}
+    content: {{{ json description }}}
   - property: "twitter:card"
     content: "summary"
   - property: "twitter:image"
@@ -23,7 +23,9 @@ meta:
 />
 
 {{/ image }}
+
 {{{ description }}}
+## Keys
 
 {{# keys }}
 - [{{ title }}](./{{ lowerCase key }}.html)

--- a/build/production/templates/fr/category.md.handlebars
+++ b/build/production/templates/fr/category.md.handlebars
@@ -23,8 +23,8 @@ meta:
 />
 
 {{/ image }}
-
 {{{ description }}}
+
 ## Keys
 
 {{# keys }}

--- a/build/production/templates/fr/page.md.handlebars
+++ b/build/production/templates/fr/page.md.handlebars
@@ -4,9 +4,9 @@ meta:
   - property: "og:title"
     content: macOS defaults > {{{ name }}} > {{{ title }}}
   - name: "description"
-    content: {{{ escapeDoubleQuote description }}}
+    content: {{{ json description }}}
   - property: "og:description"
-    content: {{{ escapeDoubleQuote description }}}
+    content: {{{ json description }}}
   - property: "twitter:card"
     content: "summary"
   - property: "twitter:image"
@@ -17,6 +17,8 @@ meta:
 # {{{ title }}}
 
 {{{ description }}}
+
+<!-- break lists -->
 
 - **Testé sur macOS**:
 {{# versions }}

--- a/build/production/templates/page.md.handlebars
+++ b/build/production/templates/page.md.handlebars
@@ -4,9 +4,9 @@ meta:
   - property: "og:title"
     content: macOS defaults > {{{ name }}} > {{{ title }}}
   - name: "description"
-    content: {{{ escapeDoubleQuote description }}}
+    content: {{{ json description }}}
   - property: "og:description"
-    content: {{{ escapeDoubleQuote description }}}
+    content: {{{ json description }}}
   - property: "twitter:card"
     content: "summary"
   - property: "twitter:image"
@@ -17,6 +17,8 @@ meta:
 # {{{ title }}}
 
 {{{ description }}}
+
+<!-- break lists -->
 
 - **Tested on macOS**:
 {{# versions }}

--- a/build/production/write-categories.js
+++ b/build/production/write-categories.js
@@ -1,10 +1,6 @@
 const fs = require('fs')
 const Handlebars = require('handlebars')
 
-Handlebars.registerHelper('escapeDoubleQuote', (string) => {
-  return string.replace(/"/g, '&#34;')
-})
-
 Handlebars.registerHelper('lowerCase', (string) => {
   return string.toLowerCase()
 })

--- a/build/production/write-categories.test.js
+++ b/build/production/write-categories.test.js
@@ -20,7 +20,7 @@ describe('write-categories', () => {
             {
               folder: 'category',
               name: 'Category',
-              description: 'Category description.',
+              description: 'This is a description of the category. It can contain "quotes" and markdown.\n\n- a list item',
               image: {
                 filename: 'category.png',
                 width: 740,

--- a/build/production/write-categories.test.js
+++ b/build/production/write-categories.test.js
@@ -2,6 +2,7 @@ const fs = require('fs')
 jest.mock('fs')
 
 const writeCategories = require('./write-categories')
+require('./handlebars-helpers')
 
 const templatesPath = 'templates'
 const destinationPath = 'dist'

--- a/build/production/write-pages.js
+++ b/build/production/write-pages.js
@@ -1,10 +1,6 @@
 const fs = require('fs')
 const Handlebars = require('handlebars')
 
-Handlebars.registerHelper('escapeDoubleQuote', (string) => {
-  return string.replace(/"/g, '&#34;')
-})
-
 module.exports = ({ defaults, url }, templatesPath, destinationPath) => {
   if (defaults.categories !== null) {
     const pageTemplate = fs.readFileSync(

--- a/build/production/write-pages.test.js
+++ b/build/production/write-pages.test.js
@@ -21,13 +21,13 @@ describe('write-pages', () => {
               {
                 folder: 'category',
                 name: 'Category',
-                description: 'Category description.',
+                description: 'This is a description of the category. It can contain "quotes" and markdown.\n\n- a list item',
                 keys: [
                   {
                     key: 'page',
                     domain: 'com.apple.category',
                     title: 'Page',
-                    description: 'Page description.',
+                    description: 'This is a description of the page. It can contain "quotes" and markdown.\n\n- a list item',
                     param: { type: 'bool' },
                     examples: [
                       {

--- a/build/production/write-pages.test.js
+++ b/build/production/write-pages.test.js
@@ -2,6 +2,7 @@ const fs = require('fs')
 jest.mock('fs')
 
 const writePages = require('./write-pages')
+require('./handlebars-helpers')
 
 const templatesPath = 'templates'
 const destinationPath = 'dist'

--- a/defaults-fr.yml
+++ b/defaults-fr.yml
@@ -4,10 +4,11 @@ categories:
 
   - folder: dock
     name: Dock
-    description:
+    description: |
       Le Dock est une composante importante de macOS.
       Il est utilisé pour lancer des applications et pour naviguer entre les applications lancées.
-      Par défaut il est placé en bas de votre écran.<br><br>
+      Par défaut il est placé en bas de votre écran.
+
       Il est personnalisable à souhait.
     image:
       filename: "dock.png"
@@ -196,12 +197,14 @@ categories:
 
   - folder: screenshots
     name: Capture d'écran
-    description:
-      "Sur un Mac, il est possible de prendre des captures d'écran avec:<br>
-      - `⌘ cmd`+`⇧ maj`+`3` pour l'écran complet.<br>
-      - `⌘ cmd`+`⇧ maj`+`4` pour une sous partie de l'écran. Ajoutez `espace` pour prendre une application entière.<br>
-      - `⌘ cmd`+`⇧ maj`+`5` pour ouvrir l'appli de capture.<br><br>
-      Il est possible de personnaliser quelques trucs."
+    description: |
+      Sur un Mac, il est possible de prendre des captures d'écran avec:
+
+      - `⌘ cmd`+`⇧ maj`+`3` pour l'écran complet.
+      - `⌘ cmd`+`⇧ maj`+`4` pour une sous partie de l'écran. Ajoutez `espace` pour prendre une application entière.
+      - `⌘ cmd`+`⇧ maj`+`5` pour ouvrir l'appli de capture.
+
+      Il est possible de personnaliser quelques trucs.
     keys:
       - key: disable-shadow
         domain: com.apple.screencapture
@@ -281,11 +284,12 @@ categories:
 
   - folder: finder
     name: Finder
-    description:
+    description: |
       Le Finder est le gestionnaire de fichier de macOS.
       Il est responsable du lancement d'autres applications,
       et pour la gestion générique des fichiers, disques externes, et volumes réseaux.
-      Depuis les années 80-90, l'icône du Finder est un écran souriant d'ordinateur, connu sous le nom "Happy Mac".<br><br>
+      Depuis les années 80-90, l'icône du Finder est un écran souriant d'ordinateur, connu sous le nom "Happy Mac".
+
       Certaines de ses fonctionnalités sont personnalisables.
     keys:
       - key: QuitMenuItem
@@ -462,13 +466,14 @@ categories:
       - key: DateFormat
         domain: com.apple.menuextra.clock
         title: Format de date et heure
-        description:
-          "Ce paramètre permet de préciser le format de date et heure de la barre de menus.
-          Les valeurs acceptées dépendent de vos paramètres de Langue & région.<br>
-          - `ss` pour les secondes.<br>
-          - `HH` pour l'heure (24h).<br>
-          - `EEE` pour le jour de la semaine en 3 lettres.<br>
-          - `d MMM` pour le jour dans le mois et le mois en 3 lettres."
+        description: |
+          Ce paramètre permet de préciser le format de date et heure de la barre de menus.
+          Les valeurs acceptées dépendent de vos paramètres de Langue & région.
+
+          - `ss` pour les secondes.
+          - `HH` pour l'heure (24h).
+          - `EEE` pour le jour de la semaine en 3 lettres.
+          - `d MMM` pour le jour dans le mois et le mois en 3 lettres.
         param:
           type: string
         examples:
@@ -490,13 +495,14 @@ categories:
 
   - folder: mission-control
     name: Mission Control
-    description:
-      "Anciennement connu sous le nom d'Exposé, Mission Control permet :<br>
-      - `⌃ ctrl`+`↑ haut` voir toutes les fenêtres d'applications ouvertes.<br>
-      - `⌃ ctrl`+`↓ bas` voir toutes les fenêtres de l'application courante.<br>
-      - `⌘ cmd`+`F3 Mission Control` cacher toutes les applications et afficher le bureau.<br>
-      - `⌃ ctrl`+`← gauche`/`→ droite` se déplacer entre les bureaux virtuels.<br>
-      - déplacer des applications entre plusieurs écrans."
+    description: |
+      Anciennement connu sous le nom d'Exposé, Mission Control permet :
+
+      - `⌃ ctrl`+`↑ haut` voir toutes les fenêtres d'applications ouvertes.
+      - `⌃ ctrl`+`↓ bas` voir toutes les fenêtres de l'application courante.
+      - `⌘ cmd`+`F3 Mission Control` cacher toutes les applications et afficher le bureau.
+      - `⌃ ctrl`+`← gauche`/`→ droite` se déplacer entre les bureaux virtuels.
+      - déplacer des applications entre plusieurs écrans.
     keys:
       - key: mru-spaces
         domain: com.apple.dock
@@ -521,8 +527,9 @@ categories:
       - key: Autogather
         domain: com.apple.appleseed.FeedbackAssistant
         title: Collecte automatique
-        description:
-          Collecter automatiquement des larges fichiers lors de la soumission de compte rendu.<br>
+        description: |
+          Collecter automatiquement des larges fichiers lors de la soumission de compte rendu.
+
           Peut ralentir significativement le Mac et envoyer de grosses quantités de données.
         param:
           type: bool
@@ -585,8 +592,9 @@ categories:
       - key: ScreenShotSaveLocation
         domain: com.apple.iphonesimulator
         title: Emplacement des screenshots
-        description:
-          Préciser le chemin par défaut des screenshots du Simulateur.<br>
+        description: |
+          Préciser le chemin par défaut des screenshots du Simulateur.
+
           Le dossier doit obligatoirement exister dans le système.
         param:
           type: string

--- a/defaults.schema.json
+++ b/defaults.schema.json
@@ -143,6 +143,9 @@
                       }
                     }
                   }
+                },
+                "after": {
+                  "type": "string"
                 }
               },
               "required": [
@@ -151,16 +154,24 @@
                 "key",
                 "param",
                 "title"
-              ]
+              ],
+              "additionalProperties": false
             },
             "uniqueItems": true
           }
-        }
+        },
+        "required": [
+          "folder",
+          "name",
+          "description"
+        ],
+        "additionalProperties": false
       },
       "uniqueItems": true
     }
   },
   "required": ["categories"],
+  "additionalProperties": false,
   "definitions": {
     "image": {
       "type": "object",

--- a/defaults.yml
+++ b/defaults.yml
@@ -4,10 +4,11 @@ categories:
 
   - folder: dock
     name: Dock
-    description:
+    description: |
       The Dock is a prominent feature of macOS.
       It is used to launch applications and to switch between running applications.
-      By default you can find it on the bottom of your screen.<br><br>
+      By default you can find it on the bottom of your screen.
+
       You can customize it as you like.
     image:
       filename: "dock.png"
@@ -196,12 +197,14 @@ categories:
 
   - folder: screenshots
     name: Screenshots
-    description:
-      "On a Mac, you can take screenshots using:<br>
-      - `⌘ cmd`+`⇧ shift`+`3` for fullscreen.<br>
-      - `⌘ cmd`+`⇧ shift`+`4` for a selection. Then use `space` to capture an entire app.<br>
-      - `⌘ cmd`+`⇧ shift`+`5` to open the Screenshot app.<br><br>
-      There is a few keys you can customize."
+    description: |
+      On a Mac, you can take screenshots using:
+
+      - `⌘ cmd`+`⇧ shift`+`3` for fullscreen.
+      - `⌘ cmd`+`⇧ shift`+`4` for a selection. Then use `space` to capture an entire app.
+      - `⌘ cmd`+`⇧ shift`+`5` to open the Screenshot app.
+
+      There are a few keys you can customize.
     keys:
       - key: disable-shadow
         domain: com.apple.screencapture
@@ -281,12 +284,13 @@ categories:
 
   - folder: finder
     name: Finder
-    description:
+    description: |
       The Finder is the default file manager on macOS.
       It is responsible for the launching of other applications,
       and for the overall user management of files, disks, and network volumes.
       In a tradition dating back to the Classic Mac OS of the 1980s and 1990s,
-      the Finder icon is the smiling screen of a computer, known as the Happy Mac logo.<br><br>
+      the Finder icon is the smiling screen of a computer, known as the Happy Mac logo.
+
       Some of its features can be customized.
     keys:
       - key: QuitMenuItem
@@ -463,13 +467,14 @@ categories:
       - key: DateFormat
         domain: com.apple.menuextra.clock
         title: Set menubar digital clock format
-        description:
-          "This setting configures the time and date format for the menubar digital clock.
-          Accepted values depend on your Language & Region settings.<br>
-          - `ss` for seconds.<br>
-          - `HH` for 24-hour clock.<br>
-          - `EEE` for 3-letter day of the week.<br>
-          - `d MMM` for day of the month and 3-letter month."
+        description: |
+          This setting configures the time and date format for the menubar digital clock.
+          Accepted values depend on your Language & Region settings.
+
+          - `ss` for seconds.
+          - `HH` for 24-hour clock.
+          - `EEE` for 3-letter day of the week.
+          - `d MMM` for day of the month and 3-letter month.
         param:
           type: string
         examples:
@@ -495,13 +500,14 @@ categories:
 
   - folder: mission-control
     name: Mission Control
-    description:
-      "Formerly known as Spaces, Mission Control allows a user to do the following:<br>
-      - `⌃ ctrl`+`↑ up` view all open application windows.<br>
-      - `⌃ ctrl`+`↓ down` view all open application windows of a specific application.<br>
-      - `⌘ cmd`+`F3 Mission Control` hide all application windows and show the desktop.<br>
-      - `⌃ ctrl`+`← left`/`→ right` manage application windows across multiple virtual desktops.<br>
-      - manage application windows across multiple monitors."
+    description: |
+      Formerly known as Spaces, Mission Control allows a user to do the following:
+
+      - `⌃ ctrl`+`↑ up` view all open application windows.
+      - `⌃ ctrl`+`↓ down` view all open application windows of a specific application.
+      - `⌘ cmd`+`F3 Mission Control` hide all application windows and show the desktop.
+      - `⌃ ctrl`+`← left`/`→ right` manage application windows across multiple virtual desktops.
+      - manage application windows across multiple monitors.
     keys:
       - key: mru-spaces
         domain: com.apple.dock
@@ -526,8 +532,9 @@ categories:
       - key: Autogather
         domain: com.apple.appleseed.FeedbackAssistant
         title: Autogather
-        description:
-          Choose whether to autogather large files when submitting a feedback report.<br>
+        description: |
+          Choose whether to autogather large files when submitting a feedback report.
+
           Can result in a slow Mac and important upload metrics.
         param:
           type: bool
@@ -592,8 +599,9 @@ categories:
       - key: ScreenShotSaveLocation
         domain: com.apple.iphonesimulator
         title: Set screenshot location
-        description:
-          Set default location for Simulator screenshots.<br>
+        description: |
+          Set default location for Simulator screenshots.
+
           Note that the folder has to exist in the filesystem.
         param:
           type: string
@@ -707,9 +715,10 @@ categories:
       - key: LSQuarantine
         domain: com.apple.LaunchServices
         title: Disable application quarantine message
-        description:
-          "Turn off the “Application Downloaded from Internet” quarantine warning.<br>
-          ⚠️ Stopped working on Big Sur."
+        description: |
+          Turn off the “Application Downloaded from Internet” quarantine warning.
+
+          ⚠️ Stopped working on Big Sur.
         param:
           type: bool
         examples:


### PR DESCRIPTION
This improves markdown support within descriptions. Currently, adding multiline text blocks in the defaults.yml file breaks, because the generated head meta tags content includes that whitespace as is and breaks the generated yaml contents (see the build error in https://github.com/yannbertrand/macos-defaults/pull/146). Now, meta tag content is stringified as JSON, which is yaml compliant. The final html meta tag contains the markdown as is. Also currently, markdown descriptions inserted into the content can interact with subsequent content (if you end with a list it'll cause funky interaction with the following content). That's fixed by inserting a "break" between (done on categories and pages).

I also tightened the JSON schema validation to avoid extra keys (from [this branch](https://github.com/yannbertrand/macos-defaults/compare/master...apexskier:domain-organization?expand=1)).

| Before (not real markdown) | Markdown issue | Current |
| --- | --- | --- |
| <img width="536" alt="Screen Shot 2021-04-04 at 16 19 51" src="https://user-images.githubusercontent.com/329222/113511750-cab29680-9561-11eb-8969-f9fc8f935b74.png"> | <img width="461" alt="Screen Shot 2021-04-04 at 16 19 44" src="https://user-images.githubusercontent.com/329222/113511751-cb4b2d00-9561-11eb-8750-e0af7a476cf3.png"> | <img width="555" alt="Screen Shot 2021-04-04 at 16 20 10" src="https://user-images.githubusercontent.com/329222/113511749-c9816980-9561-11eb-99ce-70e5fb6bb613.png"> |
| <img width="657" alt="Screen Shot 2021-04-04 at 16 18 37" src="https://user-images.githubusercontent.com/329222/113511833-28df7980-9562-11eb-944f-fd7630222a15.png"> | <img width="684" alt="Screen Shot 2021-04-04 at 16 19 39" src="https://user-images.githubusercontent.com/329222/113511752-cbe3c380-9561-11eb-90df-d23b249c972a.png"> | <img width="650" alt="Screen Shot 2021-04-04 at 16 18 40" src="https://user-images.githubusercontent.com/329222/113511753-cc7c5a00-9561-11eb-8ef4-ee5951b772a6.png"> |