### PR TITLE
:sparkles: Add support for spaces (and other specials) in keys

### DIFF
--- a/.github/workflows/test-defaults.yml
+++ b/.github/workflows/test-defaults.yml
@@ -36,8 +36,3 @@ jobs:
 
     - name: Validate 'defaults-*.yml' against schema
       uses: nwisbeta/validate-yaml-schema@v1.0.3
-      with:
-        yamlSchemasJson: |
-          {
-            "./defaults.schema.json": ["/defaults*.yml"]
-          }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,10 @@
 {
     "yaml.schemas": {
         "./defaults.schema.json": ["/defaults*.yml"]
+    },
+    "[yaml]": {
+        "editor.rulers": [
+            130
+        ]
     }
 }

--- a/build/production/__snapshots__/write-pages.test.js.snap
+++ b/build/production/__snapshots__/write-pages.test.js.snap
@@ -30,7 +30,7 @@ Page description.
 ## Set to \`true\` (default value)
 
 \`\`\`bash
-defaults write com.apple.category page -bool \\"true\\" 
+defaults write com.apple.category \\"page\\" -bool \\"true\\" 
 \`\`\`
 <img
   src=\\"./category-page-true.png\\"
@@ -41,7 +41,7 @@ defaults write com.apple.category page -bool \\"true\\"
 ## Set to \`false\`
 
 \`\`\`bash
-defaults write com.apple.category page -bool \\"false\\" 
+defaults write com.apple.category \\"page\\" -bool \\"false\\" 
 \`\`\`
 <img
   src=\\"./category-page-false.png\\"
@@ -51,12 +51,12 @@ defaults write com.apple.category page -bool \\"false\\"
 
 ## Read current value
 \`\`\`bash
-defaults read com.apple.category page
+defaults read com.apple.category \\"page\\"
 \`\`\`
 
 ## Reset to default value
 \`\`\`bash
-defaults delete com.apple.category page
+defaults delete com.apple.category \\"page\\"
 \`\`\`
 "
 `;
@@ -96,7 +96,7 @@ Page description.
 output when value is start
 
 \`\`\`bash
-defaults write com.apple.category page -string \\"start\\" 
+defaults write com.apple.category \\"page\\" -string \\"start\\" 
 \`\`\`
 
 ## Set to \`middle\` (default value)
@@ -104,7 +104,7 @@ defaults write com.apple.category page -string \\"start\\"
 output when value is middle
 
 \`\`\`bash
-defaults write com.apple.category page -string \\"middle\\" 
+defaults write com.apple.category \\"page\\" -string \\"middle\\" 
 \`\`\`
 
 ## Set to \`end\`
@@ -112,17 +112,17 @@ defaults write com.apple.category page -string \\"middle\\"
 output when value is end
 
 \`\`\`bash
-defaults write com.apple.category page -string \\"end\\" 
+defaults write com.apple.category \\"page\\" -string \\"end\\" 
 \`\`\`
 
 ## Read current value
 \`\`\`bash
-defaults read com.apple.category page
+defaults read com.apple.category \\"page\\"
 \`\`\`
 
 ## Reset to default value
 \`\`\`bash
-defaults delete com.apple.category page
+defaults delete com.apple.category \\"page\\"
 \`\`\`
 "
 `;
@@ -156,7 +156,7 @@ Page description.
 
 ## Read current value
 \`\`\`bash
-defaults read com.apple.category page
+defaults read com.apple.category \\"page\\"
 \`\`\`
 
 ## Reset to default value
@@ -164,7 +164,7 @@ defaults read com.apple.category page
 This an alert message. <br> \`defaults command\`
 :::
 \`\`\`bash
-defaults delete com.apple.category page
+defaults delete com.apple.category \\"page\\"
 \`\`\`
 "
 `;
@@ -201,7 +201,7 @@ Page description.
 output when value is ~/Desktop
 
 \`\`\`bash
-defaults write com.apple.category page -string \\"~/Desktop\\" && killall App
+defaults write com.apple.category \\"page\\" -string \\"~/Desktop\\" && killall App
 \`\`\`
 
 ## Set to \`~/Pictures\`
@@ -209,17 +209,17 @@ defaults write com.apple.category page -string \\"~/Desktop\\" && killall App
 output when value is ~/Pictures
 
 \`\`\`bash
-defaults write com.apple.category page -string \\"~/Pictures\\" && killall App
+defaults write com.apple.category \\"page\\" -string \\"~/Pictures\\" && killall App
 \`\`\`
 
 ## Read current value
 \`\`\`bash
-defaults read com.apple.category page
+defaults read com.apple.category \\"page\\"
 \`\`\`
 
 ## Reset to default value
 \`\`\`bash
-defaults delete com.apple.category page && killall App
+defaults delete com.apple.category \\"page\\" && killall App
 \`\`\`
 "
 `;
@@ -260,7 +260,7 @@ Page description.
 output when value is true
 
 \`\`\`bash
-defaults write com.apple.category page -string \\"true\\" && killall App
+defaults write com.apple.category \\"page\\" -string \\"true\\" && killall App
 \`\`\`
 
 ## Set to \`false\`
@@ -268,22 +268,22 @@ defaults write com.apple.category page -string \\"true\\" && killall App
 output when value is false
 
 \`\`\`bash
-defaults write com.apple.category page -string \\"false\\" && killall App
+defaults write com.apple.category \\"page\\" -string \\"false\\" && killall App
 \`\`\`
 
 ## Read current value
 \`\`\`bash
-defaults read com.apple.category page
+defaults read com.apple.category \\"page\\"
 \`\`\`
 
 ## Reset to default value
 \`\`\`bash
-defaults delete com.apple.category page && killall App
+defaults delete com.apple.category \\"page\\" && killall App
 \`\`\`
 "
 `;
 
-exports[`write-pages one category, one page with text example with special chars values should write a category/page.md file using the page template 1`] = `
+exports[`write-pages one category, one page with text example with special chars key and values should write a category/a-page.md file using the page template 1`] = `
 "---
 metaTitle: Page | Category | macOS defaults
 meta:
@@ -317,7 +317,7 @@ This is a description of the page. It can contain \\"quotes\\" and markdown.
 output when value is ~/Desktop
 
 \`\`\`bash
-defaults write com.apple.category page -bool \\"~/Desktop\\" 
+defaults write com.apple.category \\"a page\\" -bool \\"~/Desktop\\" 
 \`\`\`
 
 ## Set to \`~/Pictures\`
@@ -325,17 +325,17 @@ defaults write com.apple.category page -bool \\"~/Desktop\\"
 output when value is ~/Pictures
 
 \`\`\`bash
-defaults write com.apple.category page -bool \\"~/Pictures\\" 
+defaults write com.apple.category \\"a page\\" -bool \\"~/Pictures\\" 
 \`\`\`
 
 ## Read current value
 \`\`\`bash
-defaults read com.apple.category page
+defaults read com.apple.category \\"a page\\"
 \`\`\`
 
 ## Reset to default value
 \`\`\`bash
-defaults delete com.apple.category page
+defaults delete com.apple.category \\"a page\\"
 \`\`\`
 "
 `;
@@ -370,7 +370,7 @@ Page description.
 ## Set to \`0\` (default value)
 
 \`\`\`bash
-defaults write com.apple.category page -float \\"0\\" 
+defaults write com.apple.category \\"page\\" -float \\"0\\" 
 \`\`\`
 <video autoplay loop muted playsinline width=\\"750\\" height=\\"400\\" style=\\"max-width: 100%; height: auto\\">
   <source src=\\"./category-page-0.mp4\\" type=\\"video/mp4\\">
@@ -380,7 +380,7 @@ defaults write com.apple.category page -float \\"0\\"
 ## Set to \`0.5\`
 
 \`\`\`bash
-defaults write com.apple.category page -float \\"0.5\\" 
+defaults write com.apple.category \\"page\\" -float \\"0.5\\" 
 \`\`\`
 <video autoplay loop muted playsinline width=\\"720\\" height=\\"390\\" style=\\"max-width: 100%; height: auto\\">
   <source src=\\"./category-page-0.5.mp4\\" type=\\"video/mp4\\">
@@ -389,12 +389,12 @@ defaults write com.apple.category page -float \\"0.5\\"
 
 ## Read current value
 \`\`\`bash
-defaults read com.apple.category page
+defaults read com.apple.category \\"page\\"
 \`\`\`
 
 ## Reset to default value
 \`\`\`bash
-defaults delete com.apple.category page
+defaults delete com.apple.category \\"page\\"
 \`\`\`
 "
 `;
@@ -431,7 +431,7 @@ Page 1 description.
 output when value is true
 
 \`\`\`bash
-defaults write com.apple.category page1 -bool \\"true\\" 
+defaults write com.apple.category \\"page1\\" -bool \\"true\\" 
 \`\`\`
 
 ## Set to \`false\`
@@ -439,17 +439,17 @@ defaults write com.apple.category page1 -bool \\"true\\"
 output when value is false
 
 \`\`\`bash
-defaults write com.apple.category page1 -bool \\"false\\" 
+defaults write com.apple.category \\"page1\\" -bool \\"false\\" 
 \`\`\`
 
 ## Read current value
 \`\`\`bash
-defaults read com.apple.category page1
+defaults read com.apple.category \\"page1\\"
 \`\`\`
 
 ## Reset to default value
 \`\`\`bash
-defaults delete com.apple.category page1
+defaults delete com.apple.category \\"page1\\"
 \`\`\`
 "
 `;
@@ -486,7 +486,7 @@ Page 2 description.
 output when value is true
 
 \`\`\`bash
-defaults write com.apple.category page2 -bool \\"true\\" 
+defaults write com.apple.category \\"page2\\" -bool \\"true\\" 
 \`\`\`
 
 ## Set to \`false\` (default value)
@@ -494,17 +494,17 @@ defaults write com.apple.category page2 -bool \\"true\\"
 output when value is false
 
 \`\`\`bash
-defaults write com.apple.category page2 -bool \\"false\\" 
+defaults write com.apple.category \\"page2\\" -bool \\"false\\" 
 \`\`\`
 
 ## Read current value
 \`\`\`bash
-defaults read com.apple.category page2
+defaults read com.apple.category \\"page2\\"
 \`\`\`
 
 ## Reset to default value
 \`\`\`bash
-defaults delete com.apple.category page2
+defaults delete com.apple.category \\"page2\\"
 \`\`\`
 "
 `;
@@ -541,7 +541,7 @@ Page description.
 output when value is true
 
 \`\`\`bash
-defaults write com.apple.category1 page -bool \\"true\\" 
+defaults write com.apple.category1 \\"page\\" -bool \\"true\\" 
 \`\`\`
 
 ## Set to \`false\`
@@ -549,17 +549,17 @@ defaults write com.apple.category1 page -bool \\"true\\"
 output when value is false
 
 \`\`\`bash
-defaults write com.apple.category1 page -bool \\"false\\" 
+defaults write com.apple.category1 \\"page\\" -bool \\"false\\" 
 \`\`\`
 
 ## Read current value
 \`\`\`bash
-defaults read com.apple.category1 page
+defaults read com.apple.category1 \\"page\\"
 \`\`\`
 
 ## Reset to default value
 \`\`\`bash
-defaults delete com.apple.category1 page
+defaults delete com.apple.category1 \\"page\\"
 \`\`\`
 "
 `;
@@ -596,7 +596,7 @@ Page description.
 output when value is true
 
 \`\`\`bash
-defaults write com.apple.category2 page -bool \\"true\\" 
+defaults write com.apple.category2 \\"page\\" -bool \\"true\\" 
 \`\`\`
 
 ## Set to \`false\` (default value)
@@ -604,17 +604,17 @@ defaults write com.apple.category2 page -bool \\"true\\"
 output when value is false
 
 \`\`\`bash
-defaults write com.apple.category2 page -bool \\"false\\" 
+defaults write com.apple.category2 \\"page\\" -bool \\"false\\" 
 \`\`\`
 
 ## Read current value
 \`\`\`bash
-defaults read com.apple.category2 page
+defaults read com.apple.category2 \\"page\\"
 \`\`\`
 
 ## Reset to default value
 \`\`\`bash
-defaults delete com.apple.category2 page
+defaults delete com.apple.category2 \\"page\\"
 \`\`\`
 "
 `;

--- a/build/production/handlebars-helpers.js
+++ b/build/production/handlebars-helpers.js
@@ -1,5 +1,8 @@
 const Handlebars = require('handlebars')
+const slugify = require('slugify')
 
 Handlebars.registerHelper('metaTag', (string) => {
   return JSON.stringify(string.replace(/"/g, '&quot;'))
 })
+
+Handlebars.registerHelper('slugify', slugify)

--- a/build/production/package.json
+++ b/build/production/package.json
@@ -23,7 +23,8 @@
   "devDependencies": {
     "jest": "26.6.3",
     "prettier": "2.2.1",
-    "rimraf": "3.0.2"
+    "rimraf": "3.0.2",
+    "slugify": "^1.5.0"
   },
   "resolutions": {
     "vuepress/@vuepress/core/webpack-dev-server/selfsigned/node-forge": "0.10.0",

--- a/build/production/templates/.vuepress/config.yml.handlebars
+++ b/build/production/templates/.vuepress/config.yml.handlebars
@@ -108,7 +108,7 @@ themeConfig:
           path: '{{ ../url }}{{ folder }}/'
           children:
         {{# keys }}
-            - '{{ ../../url }}{{ ../folder }}/{{ lowerCase key }}'
+            - '{{ ../../url }}{{ ../folder }}/{{ slugify key }}'
         {{/ keys}}
       {{/ defaults.categories }}
   {{/ languages }}

--- a/build/production/templates/category.md.handlebars
+++ b/build/production/templates/category.md.handlebars
@@ -28,5 +28,5 @@ meta:
 ## Keys
 
 {{# keys }}
-- [{{ title }}](./{{ lowerCase key }}.html)
+- [{{ title }}](./{{ slugify key }}.html)
 {{/ keys }}

--- a/build/production/templates/fr/category.md.handlebars
+++ b/build/production/templates/fr/category.md.handlebars
@@ -28,5 +28,5 @@ meta:
 ## Keys
 
 {{# keys }}
-- [{{ title }}](./{{ lowerCase key }}.html)
+- [{{ title }}](./{{ slugify key }}.html)
 {{/ keys }}

--- a/build/production/templates/fr/home.md.handlebars
+++ b/build/production/templates/fr/home.md.handlebars
@@ -69,7 +69,7 @@ defaults rename ${domain} ${old_key} ${new_key}
 {{# categories }}
 ### {{ name }}
 {{# keys }}
-- [{{ title }}](./{{ ../folder }}/{{ lowerCase key }}.html)
+- [{{ title }}](./{{ ../folder }}/{{ slugify key }}.html)
 {{/ keys}}
 
 {{/ categories }}

--- a/build/production/templates/fr/page.md.handlebars
+++ b/build/production/templates/fr/page.md.handlebars
@@ -46,7 +46,7 @@ meta:
 {{/ if}}
 
 ```bash
-defaults write {{ ../domain }} {{ ../key }} -{{# if command }}{{ command }}{{ else }}{{ ../param.type }}{{/ if }} {{# each value }}{{{ shellescape this }}} {{/ each }}{{# if ../after }}&& {{ ../after }}{{/ if }}
+defaults write {{ ../domain }} {{{ shellescape ../key }}} -{{# if command }}{{ command }}{{ else }}{{ ../param.type }}{{/ if }} {{# each value }}{{{ shellescape this }}} {{/ each }}{{# if ../after }}&& {{ ../after }}{{/ if }}
 ```
 {{# video }}
 <video autoplay loop muted playsinline width="{{ width }}" height="{{ height }}" style="max-width: 100%; height: auto">
@@ -65,7 +65,7 @@ defaults write {{ ../domain }} {{ ../key }} -{{# if command }}{{ command }}{{ el
 {{/ examples }}
 ## Lire la valeur courante
 ```bash
-defaults read {{ domain }} {{ key }}
+defaults read {{ domain }} {{{ shellescape key }}}
 ```
 
 ## Remettre la valeur à l'état initial
@@ -75,5 +75,5 @@ defaults read {{ domain }} {{ key }}
 :::
 {{/ if }}
 ```bash
-defaults delete {{ domain }} {{ key }}{{# if after }} && {{ after }}{{/ if }}
+defaults delete {{ domain }} {{{ shellescape key }}}{{# if after }} && {{ after }}{{/ if }}
 ```

--- a/build/production/templates/home.md.handlebars
+++ b/build/production/templates/home.md.handlebars
@@ -69,7 +69,7 @@ defaults rename ${domain} ${old_key} ${new_key}
 {{# categories }}
 ### {{ name }}
 {{# keys }}
-- [{{ title }}](./{{ ../folder }}/{{ lowerCase key }}.html)
+- [{{ title }}](./{{ ../folder }}/{{ slugify key }}.html)
 {{/ keys}}
 
 {{/ categories }}

--- a/build/production/templates/page.md.handlebars
+++ b/build/production/templates/page.md.handlebars
@@ -46,7 +46,7 @@ meta:
 {{/ if}}
 
 ```bash
-defaults write {{ ../domain }} {{ ../key }} -{{# if command }}{{ command }}{{ else }}{{ ../param.type }}{{/ if }} {{# each value }}{{{ shellescape this }}} {{/ each }}{{# if ../after }}&& {{ ../after }}{{/ if }}
+defaults write {{ ../domain }} {{{ shellescape ../key }}} -{{# if command }}{{ command }}{{ else }}{{ ../param.type }}{{/ if }} {{# each value }}{{{ shellescape this }}} {{/ each }}{{# if ../after }}&& {{ ../after }}{{/ if }}
 ```
 {{# video }}
 <video autoplay loop muted playsinline width="{{ width }}" height="{{ height }}" style="max-width: 100%; height: auto">
@@ -65,7 +65,7 @@ defaults write {{ ../domain }} {{ ../key }} -{{# if command }}{{ command }}{{ el
 {{/ examples }}
 ## Read current value
 ```bash
-defaults read {{ domain }} {{ key }}
+defaults read {{ domain }} {{{ shellescape key }}}
 ```
 
 ## Reset to default value
@@ -75,5 +75,5 @@ defaults read {{ domain }} {{ key }}
 :::
 {{/ if }}
 ```bash
-defaults delete {{ domain }} {{ key }}{{# if after }} && {{ after }}{{/ if }}
+defaults delete {{ domain }} {{{ shellescape key }}}{{# if after }} && {{ after }}{{/ if }}
 ```

--- a/build/production/write-categories.js
+++ b/build/production/write-categories.js
@@ -1,10 +1,6 @@
 const fs = require('fs')
 const Handlebars = require('handlebars')
 
-Handlebars.registerHelper('lowerCase', (string) => {
-  return string.toLowerCase()
-})
-
 module.exports = (defaults, templatesPath, destinationPath) => {
   if (defaults.categories !== null) {
     const categoryTemplate = fs.readFileSync(

--- a/build/production/write-config.js
+++ b/build/production/write-config.js
@@ -1,10 +1,6 @@
 const fs = require('fs')
 const Handlebars = require('handlebars')
 
-Handlebars.registerHelper('lowerCase', (string) => {
-  return string.toLowerCase()
-})
-
 module.exports = (supportedLanguages, templatesPath, destinationPath) => {
   fs.mkdirSync(`${destinationPath}/.vuepress`)
   fs.mkdirSync(`${destinationPath}/.vuepress/public`)

--- a/build/production/write-config.test.js
+++ b/build/production/write-config.test.js
@@ -2,6 +2,7 @@ const fs = require('fs')
 jest.mock('fs')
 
 const writeConfig = require('./write-config')
+require('./handlebars-helpers')
 
 const templatesPath = 'templates'
 const destinationPath = 'dist'

--- a/build/production/write-homepage.js
+++ b/build/production/write-homepage.js
@@ -1,10 +1,6 @@
 const fs = require('fs')
 const Handlebars = require('handlebars')
 
-Handlebars.registerHelper('lowerCase', (string) => {
-  return string.toLowerCase()
-})
-
 module.exports = (defaults, templatesPath, destinationPath) => {
   fs.mkdirSync(destinationPath)
 

--- a/build/production/write-homepage.test.js
+++ b/build/production/write-homepage.test.js
@@ -2,6 +2,7 @@ const fs = require('fs')
 jest.mock('fs')
 
 const writeHomepage = require('./write-homepage')
+require('./handlebars-helpers')
 
 const templatesPath = 'templates'
 const destinationPath = 'dist'

--- a/build/production/write-pages.js
+++ b/build/production/write-pages.js
@@ -1,5 +1,6 @@
 const fs = require('fs')
 const Handlebars = require('handlebars')
+const slugify = require('slugify')
 
 module.exports = ({ defaults, url }, templatesPath, destinationPath) => {
   if (defaults.categories !== null) {
@@ -30,7 +31,7 @@ module.exports = ({ defaults, url }, templatesPath, destinationPath) => {
           url,
         })
         fs.writeFileSync(
-          `${destinationPath}/${folder}/${page.key.toLowerCase()}.md`,
+          `${destinationPath}/${folder}/${slugify(page.key)}.md`,
           pageReadmeContent
         )
 

--- a/build/production/write-pages.test.js
+++ b/build/production/write-pages.test.js
@@ -14,7 +14,7 @@ describe('write-pages', () => {
 
   describe('one category, one page', () => {
     describe('with text example', () => {
-      describe('with special chars values', () => {
+      describe('with special chars key and values', () => {
         beforeEach(() =>
           callWritePages({
             categories: [
@@ -24,7 +24,7 @@ describe('write-pages', () => {
                 description: 'This is a description of the category. It can contain "quotes" and markdown.\n\n- a list item',
                 keys: [
                   {
-                    key: 'page',
+                    key: 'a page',
                     domain: 'com.apple.category',
                     title: 'Page',
                     description: 'This is a description of the page. It can contain "quotes" and markdown.\n\n- a list item',
@@ -48,9 +48,9 @@ describe('write-pages', () => {
           })
         )
 
-        it('should write a category/page.md file using the page template', () => {
+        it('should write a category/a-page.md file using the page template', () => {
           const pageReadmeContent = readFile(
-            `${destinationPath}/category/page.md`
+            `${destinationPath}/category/a-page.md`
           )
           expect(pageReadmeContent).toMatchSnapshot()
         })

--- a/build/production/yarn.lock
+++ b/build/production/yarn.lock
@@ -8137,6 +8137,11 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
+slugify@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.5.0.tgz#5f3c8e2a84105b54eb51486db1b468a599b3c9b8"
+  integrity sha512-Q2UPZ2udzquy1ElHfOLILMBMqBEXkiD3wE75qtBvV+FsDdZZjUqPZ44vqLTejAVq+wLLHacOMcENnP8+ZbzmIA==
+
 smoothscroll-polyfill@^0.4.3:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/smoothscroll-polyfill/-/smoothscroll-polyfill-0.4.4.tgz#3a259131dc6930e6ca80003e1cb03b603b69abf8"


### PR DESCRIPTION
Currently, page url generation (slugification) is just toLowerCase. In https://github.com/yannbertrand/macos-defaults/pull/146 I add some defaults that contain keys with spaces, which currently breaks.

This pulls in `slugify` to add support, and shell escapes keys in examples.