### PR TITLE
Add more Finder-related commands

### DIFF
--- a/defaults.yml
+++ b/defaults.yml
@@ -378,6 +378,20 @@ categories:
               height: 451
         versions: [Monterey, Big Sur, Catalina]
         after: killall Finder
+      - key: ShowPathbar
+        domain: com.apple.finder
+        title: Path bar
+        description: Show path bar in the bottom of the Finder windows
+        param:
+          type: bool
+        examples:
+          - text: Show path bar
+            value: true
+          - text: Hide path bar
+            default: true
+            value: false
+        versions: [Monterey, Big Sur]
+        after: killall Finder
       - key: FXEnableExtensionChangeWarning
         domain: com.apple.finder
         title: Changing file extension warning

--- a/defaults.yml
+++ b/defaults.yml
@@ -504,6 +504,20 @@ categories:
             value: true
         versions: [Monterey, Big Sur]
         after: killall Finder
+      - key: ShowHardDrivesOnDesktop
+        domain: com.apple.finder
+        title: Disks
+        description: Show hard disks on desktop
+        param:
+          type: bool
+        examples:
+          - text: Show hard disks
+            value: true
+          - text: Hide hard disks
+            default: true
+            value: false
+        versions: [Monterey, Big Sur]
+        after: killall Finder
 
   - folder: menubar
     name: Menu Bar

--- a/defaults.yml
+++ b/defaults.yml
@@ -518,6 +518,20 @@ categories:
             value: false
         versions: [Monterey, Big Sur]
         after: killall Finder
+      - key: ShowExternalHardDrivesOnDesktop
+        domain: com.apple.finder
+        title: External disks
+        description: Hide external disks on desktop
+        param:
+          type: bool
+        examples:
+          - text: Hide external disks
+            value: false
+          - text: Show external disks
+            default: true
+            value: true
+        versions: [Monterey, Big Sur]
+        after: killall Finder
 
   - folder: menubar
     name: Menu Bar

--- a/defaults.yml
+++ b/defaults.yml
@@ -546,6 +546,20 @@ categories:
             value: true
         versions: [Monterey, Big Sur]
         after: killall Finder
+      - key: ShowMountedServersOnDesktop
+        domain: com.apple.finder
+        title: Connected servers
+        description: Show connected servers on desktop
+        param:
+          type: bool
+        examples:
+          - text: Show connected servers
+            value: true
+          - text: Hide connected servers
+            default: true
+            value: false
+        versions: [Monterey, Big Sur]
+        after: killall Finder
 
   - folder: menubar
     name: Menu Bar

--- a/defaults.yml
+++ b/defaults.yml
@@ -410,6 +410,20 @@ categories:
             text: Icon view
         versions: [Monterey, Big Sur]
         after: killall Finder
+      - key: _FXSortFoldersFirst
+        domain: com.apple.finder
+        title: Keep folders on top
+        description: Keep folders on top when sorting by name
+        param:
+          type: bool
+        examples:
+          - value: true
+            text: Keep folders on top
+          - value: false
+            default: true
+            text: Do not keep folders on top
+        versions: [Monterey, Big Sur]
+        after: killall Finder
       - key: FXEnableExtensionChangeWarning
         domain: com.apple.finder
         title: Changing file extension warning

--- a/defaults.yml
+++ b/defaults.yml
@@ -424,6 +424,22 @@ categories:
             text: Do not keep folders on top
         versions: [Monterey, Big Sur]
         after: killall Finder
+      - key: FXDefaultSearchScope
+        domain: com.apple.finder
+        title: Default search scope
+        description: Set the default search scope when performing a search
+        param:
+          type: string
+        examples:
+          - text: Search the current folder
+            value: SCcf
+          - text: Use the previous search scope
+            value: SCsp
+          - text: Search this Mac
+            default: true
+            value: SCev
+        versions: [Monterey, Big Sur]
+        after: killall Finder
       - key: FXEnableExtensionChangeWarning
         domain: com.apple.finder
         title: Changing file extension warning

--- a/defaults.yml
+++ b/defaults.yml
@@ -490,6 +490,20 @@ categories:
             text: Don't keep folders on top
         versions: [Monterey, Big Sur]
         after: killall Finder
+      - key: CreateDesktop
+        domain: com.apple.finder
+        title: All icons
+        description: Hide all icons on desktop
+        param:
+          type: bool
+        examples:
+          - text: Hide all icons
+            value: false
+          - text: Show all icons
+            default: true
+            value: true
+        versions: [Monterey, Big Sur]
+        after: killall Finder
 
   - folder: menubar
     name: Menu Bar

--- a/defaults.yml
+++ b/defaults.yml
@@ -532,6 +532,20 @@ categories:
             value: true
         versions: [Monterey, Big Sur]
         after: killall Finder
+      - key: ShowRemovableMediaOnDesktop
+        domain: com.apple.finder
+        title: Removable media
+        description: Hide removable media _(CDs, DVDs and iPods)_ on desktop
+        param:
+          type: bool
+        examples:
+          - text: Hide removable media
+            value: false
+          - text: Show removable media
+            default: true
+            value: true
+        versions: [Monterey, Big Sur]
+        after: killall Finder
 
   - folder: menubar
     name: Menu Bar

--- a/defaults.yml
+++ b/defaults.yml
@@ -392,6 +392,24 @@ categories:
             value: false
         versions: [Monterey, Big Sur]
         after: killall Finder
+      - key: FXPreferredViewStyle
+        domain: com.apple.finder
+        title: Default view style
+        description: Set the default view style for folders without custom setting
+        param:
+          type: string
+        examples:
+          - value: clmv
+            text: Column view
+          - value: Nlsv
+            text: List view
+          - value: glyv
+            text: Gallery View
+          - value: icnv
+            default: true
+            text: Icon view
+        versions: [Monterey, Big Sur]
+        after: killall Finder
       - key: FXEnableExtensionChangeWarning
         domain: com.apple.finder
         title: Changing file extension warning

--- a/defaults.yml
+++ b/defaults.yml
@@ -440,6 +440,20 @@ categories:
             value: SCev
         versions: [Monterey, Big Sur]
         after: killall Finder
+      - key: FXRemoveOldTrashItems
+        domain: com.apple.finder
+        title: Empty bin items after 30 days
+        description: Remove items in the bin after 30 days
+        param:
+          type: bool
+        examples:
+          - text: Automatically empty bin after 30 days
+            value: true
+          - text: Keep bin as is
+            default: true
+            value: false
+        versions: [Monterey, Big Sur]
+        after: killall Finder
       - key: FXEnableExtensionChangeWarning
         domain: com.apple.finder
         title: Changing file extension warning

--- a/defaults.yml
+++ b/defaults.yml
@@ -470,6 +470,27 @@ categories:
         versions: [Monterey, Big Sur, Catalina]
         after: killall Finder
 
+  - folder: desktop
+    name: Desktop
+    description: |
+      Desktop shows files and icons on a background, works as a part of the Finder.
+      The desktop view can be customized.
+    keys:
+      - key: _FXSortFoldersFirstOnDesktop
+        domain: com.apple.finder
+        title: Keep folders on top
+        description: Keep folders on top when sorting
+        param:
+          type: bool
+        examples:
+          - value: true
+            text: Keep folders on top
+          - value: false
+            default: true
+            text: Don't keep folders on top
+        versions: [Monterey, Big Sur]
+        after: killall Finder
+
   - folder: menubar
     name: Menu Bar
     description:


### PR DESCRIPTION
Adds:
- desktop section with
  - keep folders on top
  - show/hide all icons
  - show/hide hard disks
  - show/hide external disks
  - show/hide removable media
  - show/hide connected servers
- path bar
- ~~title bar icons (#173)~~  
  see #223
- default view style
- keep folders on top
- default search scope
- empty bin items after 30 days