### PR TITLE
:bug: Fix quotes escaping in example titles

### DIFF
--- a/build/__snapshots__/write-pages.test.js.snap
+++ b/build/__snapshots__/write-pages.test.js.snap
@@ -320,12 +320,12 @@ output when value is ~/Desktop
 defaults write com.apple.category \\"a page\\" -bool \\"~/Desktop\\" 
 \`\`\`
 
-## Set to \`~/Pictures\`
+## Set to \`\\"EEE d MMM HH:mm:ss\\"\`
 
-output when value is ~/Pictures
+output when value is \\"EEE d MMM HH:mm:ss\\"
 
 \`\`\`bash
-defaults write com.apple.category \\"a page\\" -bool \\"~/Pictures\\" 
+defaults write com.apple.category \\"a page\\" -bool \\"\\\\\\"EEE d MMM HH:mm:ss\\\\\\"\\" 
 \`\`\`
 
 ## Read current value

--- a/build/templates/fr/page.md.handlebars
+++ b/build/templates/fr/page.md.handlebars
@@ -32,12 +32,12 @@ meta:
 {{# if requirements }}
 ## Prérequis
 {{# requirements }}
-- [`{{ name }}`](../..{{ ../url }}{{ folder }}/{{ key }}.html#avec-la-valeur-{{ value }}) doit avoir la valeur `{{ value }}`
+- [`{{ name }}`](../..{{ ../url }}{{ folder }}/{{ key }}.html#avec-la-valeur-{{{ value }}}) doit avoir la valeur `{{ value }}`
 {{/ requirements }}
 
 {{/ if }}
 {{# examples }}
-## {{# if title }}{{{ title }}}{{ else }}Avec la valeur `{{ value }}`{{/ if }}{{# if default }} (par défaut){{/ if }}
+## {{# if title }}{{{ title }}}{{ else }}Avec la valeur `{{{ value }}}`{{/ if }}{{# if default }} (par défaut){{/ if }}
 {{# if text }}
 
 {{# text }}

--- a/build/templates/page.md.handlebars
+++ b/build/templates/page.md.handlebars
@@ -32,12 +32,12 @@ meta:
 {{# if requirements }}
 ## Requirements
 {{# requirements }}
-- [`{{ name }}`](../../{{ folder }}/{{ key }}.html#set-to-{{ value }}) must be set to `{{ value }}`
+- [`{{ name }}`](../../{{ folder }}/{{ key }}.html#set-to-{{{ value }}}) must be set to `{{ value }}`
 {{/ requirements }}
 
 {{/ if }}
 {{# examples }}
-## {{# if title }}{{{ title }}}{{ else }}Set to `{{ value }}`{{/ if }}{{# if default }} (default value){{/ if }}
+## {{# if title }}{{{ title }}}{{ else }}Set to `{{{ value }}}`{{/ if }}{{# if default }} (default value){{/ if }}
 {{# if text }}
 
 {{# text }}

--- a/build/write-pages.test.js
+++ b/build/write-pages.test.js
@@ -36,8 +36,8 @@ describe('write-pages', () => {
                         text: 'output when value is ~/Desktop',
                       },
                       {
-                        value: '~/Pictures',
-                        text: 'output when value is ~/Pictures',
+                        value: '"EEE d MMM HH:mm:ss"',
+                        text: 'output when value is "EEE d MMM HH:mm:ss"',
                       },
                     ],
                     versions: ['Big Sur'],


### PR DESCRIPTION
```diff
- ## Set to &quot;EEE d MMM HH:mm:ss&quot;
+ ## Set to "EEE d MMM HH:mm:ss";
```

Fix bug introduced in 39cc31f0138aa36869556fc556c291ef9d443def