### PR TITLE
Add trackpad category

### DIFF
--- a/defaults.yml
+++ b/defaults.yml
@@ -775,6 +775,20 @@ categories:
             text: "Firm"
         versions: [Monterey]
         # TODO: add killall command
+      - key: ActuationStrength
+        domain: com.apple.AppleMultitouchTrackpad
+        title: Silent clicking
+        description: Choose whether clicking the trackpad makes a noise.
+        param:
+          type: bool
+        # TODO: add default value
+        examples:
+          - value: true
+            text: Clicking the trackpad does not make a noise.
+          - value: false
+            text: Clicking the trackpad makes a noise.
+        versions: [Monterey]
+        # TODO: add killall command
 
   - folder: mission-control
     name: Mission Control

--- a/defaults.yml
+++ b/defaults.yml
@@ -758,6 +758,23 @@ categories:
     name: Trackpad
     description: The trackpad is hardware to control the cursor that comes on all MacBooks.
     keys:
+      - key: FirstClickThreshold
+        domain: com.apple.AppleMultitouchTrackpad
+        title: Click weight (threshold)
+        description: Choose between Light/Medium/Firm.
+        param:
+          type: int
+          values: [0, 1, 2]
+        # TODO: add default value
+        examples:
+          - value: 0
+            text: "Light"
+          - value: 1
+            text: "Medium"
+          - value: 2
+            text: "Firm"
+        versions: [Monterey]
+        # TODO: add killall command
 
   - folder: mission-control
     name: Mission Control

--- a/defaults.yml
+++ b/defaults.yml
@@ -789,6 +789,42 @@ categories:
             text: Clicking the trackpad makes a noise.
         versions: [Monterey]
         # TODO: add killall command
+      - key: DragLock
+        domain: com.apple.AppleMultitouchTrackpad
+        title: Enable dragging with drag lock
+        description: Mutually exclusive with `Dragging` and `TrackpadThreeFingerDrag`.
+        param:
+          type: bool
+        examples:
+          - value: true
+          - value: false
+            default: true
+        versions: [Monterey]
+        # TODO: add killall command
+      - key: Dragging
+        domain: com.apple.AppleMultitouchTrackpad
+        title: Enable dragging without drag lock
+        description: Mutually exclusive with `DragLock` and `TrackpadThreeFingerDrag`.
+        param:
+          type: bool
+        examples:
+          - value: true
+          - value: false
+            default: true
+        versions: [Monterey]
+        # TODO: add killall command
+      - key: TrackpadThreeFingerDrag
+        domain: com.apple.AppleMultitouchTrackpad
+        title: Enable dragging with three finger drag
+        description: Mutually exclusive with `Dragging` and `DragLock`.
+        param:
+          type: bool
+        examples:
+          - value: true
+          - value: false
+            default: true
+        versions: [Monterey]
+        # TODO: add killall command
 
   - folder: mission-control
     name: Mission Control

--- a/defaults.yml
+++ b/defaults.yml
@@ -754,6 +754,11 @@ categories:
             text: Thu 21:46:18
         versions: [Monterey, Big Sur, Catalina]
 
+  - folder: trackpad
+    name: Trackpad
+    description: The trackpad is hardware to control the cursor that comes on all MacBooks.
+    keys:
+
   - folder: mission-control
     name: Mission Control
     description: |


### PR DESCRIPTION
There are many more to be added under `com.apple.AppleMultitouchTrackpad` and `NSGlobalDomain/com.apple.trackpad.*`.