### PR TITLE
Add com.apple.keyboard.fnState command

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -446,6 +446,10 @@ export default defineConfig({
             text: 'Close confirm changes popup',
             link: '/misc/nsclosealwaysconfirmschanges.md',
           },
+          {
+            text: 'Function keys behavior',
+            link: '/misc/applekeyboardfnstate.md',
+          },
         ],
       },
     ],

--- a/docs/index.md
+++ b/docs/index.md
@@ -183,7 +183,7 @@ defaults rename ${domain} ${old_key} ${new_key}
 - [Key held down behavior](./misc/applepressandholdenabled.md)
 - [Focus Follows Mouse](./misc/focusfollowsmouse.md)
 - [Close confirm changes popup](./misc/nsclosealwaysconfirmschanges.md)
-- [Function keys behavior](./applekeyboardfnstate.md)
+- [Function keys behavior](./misc/applekeyboardfnstate.md)
 
 ## 🤔 How do I add a command?
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -183,6 +183,7 @@ defaults rename ${domain} ${old_key} ${new_key}
 - [Key held down behavior](./misc/applepressandholdenabled.md)
 - [Focus Follows Mouse](./misc/focusfollowsmouse.md)
 - [Close confirm changes popup](./misc/nsclosealwaysconfirmschanges.md)
+- [Function keys behavior](./applekeyboardfnstate.md)
 
 ## 🤔 How do I add a command?
 

--- a/docs/misc/applekeyboardfnstate.md
+++ b/docs/misc/applekeyboardfnstate.md
@@ -25,20 +25,20 @@ Allows you to change the behavior of the function keys. The two possible options
   - Sonoma
 - **Parameter type**: bool
 
-## Set to `true`
-
-`F1`, `F2`, etc. behave as standard function keys. Press the `fn` key to use the special features printed on the key.
-
-```bash
-defaults write NSGlobalDomain com.apple.keyboard.fnState -bool true
-```
-
 ## Set to `false` (default value)
 
 By default, pressing a function key will perform the special feature printed on that key.
 
 ```bash
 defaults write NSGlobalDomain com.apple.keyboard.fnState -bool false
+```
+
+## Set to `true`
+
+`F1`, `F2`, etc. behave as standard function keys. Press the `fn` key to use the special features printed on the key.
+
+```bash
+defaults write NSGlobalDomain com.apple.keyboard.fnState -bool true
 ```
 
 ## Read current value

--- a/docs/misc/applekeyboardfnstate.md
+++ b/docs/misc/applekeyboardfnstate.md
@@ -1,0 +1,54 @@
+---
+title: Function keys behavior | Miscellaneous
+description: Allows you to change the behavior of the function keys.
+head:
+  - - meta
+    - property: 'og:title'
+      content: macOS defaults > Miscellaneous > Function keys behaviour
+  - - meta
+    - property: 'og:description'
+      content: Allows you to change the behavior of the function keys.
+---
+
+# Function keys behavior
+
+Allows you to change the behavior of the function keys. The two possible options are:
+
+- Use `F1`, `F2`, etc. as special keys (default)
+- Use `F1`, `F2`, etc. as standard function keys
+
+⚠️ A restart of your Mac is required to apply these changes.
+
+<!-- break lists -->
+
+- **Tested on macOS**:
+  - Sonoma
+- **Parameter type**: bool
+
+## Set to `true`
+
+`F1`, `F2`, etc. behave as standard function keys. Press the `fn` key to use the special features printed on the key.
+
+```bash
+defaults write NSGlobalDomain com.apple.keyboard.fnState -bool true
+```
+
+## Set to `false` (default value)
+
+By default, pressing a function key will perform the special feature printed on that key.
+
+```bash
+defaults write NSGlobalDomain com.apple.keyboard.fnState -bool false
+```
+
+## Read current value
+
+```bash
+defaults read NSGlobalDomain com.apple.keyboard.fnState
+```
+
+## Reset to default value
+
+```bash
+defaults delete NSGlobalDomain com.apple.keyboard.fnState
+```

--- a/docs/misc/index.md
+++ b/docs/misc/index.md
@@ -23,3 +23,4 @@ All the others `defaults` that don't deserve their own category.
 - [Key held down behavior](./applepressandholdenabled.md)
 - [Focus Follows Mouse](./focusfollowsmouse.md)
 - [Close confirm changes popup](./nsclosealwaysconfirmschanges.md)
+- [Function keys behavior](./applekeyboardfnstate.md)


### PR DESCRIPTION
👋🏼 Hi there!

Added a command for Settings > Keyboard > Function Keys > Use F1, F2, etc. as standard function keys.

<img width="500" alt="screenshot" src="https://github.com/yannbertrand/macos-defaults/assets/25246106/841ede20-a09b-4d25-a820-495a117e69d8">

Let me know if I've missed anything!