### PR TITLE
Add Finder's FinderSpawnTab option

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -210,6 +210,7 @@ export default defineConfig({
         'showpathbar.md',
         'fxpreferredviewstyle.md',
         '_fxsortfoldersfirst.md',
+        'finderspawntab.md',
         'fxdefaultsearchscope.md',
         'fxremoveoldtrashitems.md',
         'fxenableextensionchangewarning.md',

--- a/docs/finder/finderspawntab.md
+++ b/docs/finder/finderspawntab.md
@@ -1,0 +1,47 @@
+---
+title: Open folders in new tab or new window | Finder
+description: Set whether folders open in a new tab or a new window
+head:
+  - - meta
+    - property: 'og:title'
+      content: macOS defaults > Finder > Open folders in new tab or new window
+  - - meta
+    - property: 'og:description'
+      content: Set whether folders open in a new tab or a new window
+---
+
+# Open folders in new tab or new window
+
+Set whether folders shown in the Finder open in a new tab or a new window when using `⌘ cmd`+`double-click`, and which option is shown in the context menu.
+
+- **Tested on macOS**:
+  - Sonoma
+- **Parameter type**: bool
+
+## Set to `true` (default value)
+
+Open folders in a new tab
+
+```bash
+defaults write com.apple.finder "FinderSpawnTab" -bool "true" && killall Finder
+```
+
+## Set to `false`
+
+Open folders in a new window
+
+```bash
+defaults write com.apple.finder "FinderSpawnTab" -bool "false" && killall Finder
+```
+
+## Read current value
+
+```bash
+defaults read com.apple.finder "FinderSpawnTab"
+```
+
+## Reset to default value
+
+```bash
+defaults delete com.apple.finder "FinderSpawnTab" && killall Finder
+```


### PR DESCRIPTION
This PR adds Finder's `FinderSpawnTab` option, which controls whether the Finder offers "Open in New Tab" (the default in recent macOS versions) or "Open in New Window" when interacting with folders.

I've only tested option this under macOS Sonoma. I suspect that it's been consistent across the last several OS versions, but I can't directly confirm.

In Sonoma, this option can be controlled from the "General" tab in Finder Settings via the checkbox at the bottom:

<img width="377" alt="Finder Settings" src="https://github.com/user-attachments/assets/c5dcd98f-642b-4b61-8204-bbe319d54e89">

It controls what happens if you hold `Cmd` while double-clicking a folder, as well as the top option in the context menu for a folder:

### With `FinderSpawnTab` enabled (the default)

<img width="953" alt="Context menu offers Open in New Tab" src="https://github.com/user-attachments/assets/cabc5bd6-d9bd-436f-8981-33bf121cb449">

### With `FinderSpawnTab` disabled

<img width="953" alt="Context Menu offers Open in New Window" src="https://github.com/user-attachments/assets/c7ca78f2-e450-41ac-b135-7de02e63fb27">

Personally, having folders open in a new tab drives me crazy because I often want to drag items between the parent and child folders. 😝

Love the project! Please let me know if you need anything else for this PR.