### PR TITLE
:sparkles: Add command to clear time zones from Calendar

### DIFF
--- a/docs/misc/calendar-timezones.md
+++ b/docs/misc/calendar-timezones.md
@@ -1,0 +1,33 @@
+---
+title: Clear recently used time zones in Calendar | Miscellaneous
+description: Clear all recently used time zones from the time zone selector in Calendar when time zone support is enabled (Calendar → Settings → Advanced → Turn on time zone support).
+head:
+  - - meta
+    - property: 'og:title'
+      content: macOS defaults > Miscellaneous > Clear recently used time zones in Calendar
+  - - meta
+    - property: 'og:description'
+      content: Clear all recently used time zones from the time zone selector in Calendar when time zone support is enabled (Calendar → Settings → Advanced → Turn on time zone support).
+---
+
+# Clear recently used time zones in Calendar
+
+Clear all recently used time zones from the time zone selector in Calendar when time zone support is enabled (Calendar → Settings → Advanced → Turn on time zone support).
+
+- **Tested on macOS**:
+  - Sequoia
+- **Parameter type**: N/A
+
+## Read current value
+
+```bash
+defaults read com.apple.iCal "RecentlyUsedTimeZones"
+```
+
+## Reset to default value
+
+Clear recently used time zones.
+
+```bash
+defaults delete com.apple.iCal "RecentlyUsedTimeZones"
+```


### PR DESCRIPTION
- Added page to clear time zones from Calendar (`docs/miscellaneous/calendar-timezones.md`)
- Verified lint style with `npm run lint`
- Verified run with `npm start`

Resolves https://github.com/yannbertrand/macos-defaults/issues/439