### PR TITLE
Add DisableTilingAnimations documentation

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -252,6 +252,7 @@ export default defineConfig({
         'mru-spaces.md',
         'expose-group-apps.md',
         'applespacesswitchonactivate.md',
+        'disable-tiling-animations.md',
         'mission-control/spans-displays.md',
 
         'feedback-assistant',

--- a/docs/mission-control/disable-tiling-animations.md
+++ b/docs/mission-control/disable-tiling-animations.md
@@ -12,7 +12,7 @@ head:
 
 # Disable window tiling animations
 
-Disable the animation used when tiling windows (triggered by `fn`+`ctrl`+`→ right`).
+Toggles the resize animations triggered by tiling windows with the `fn`+`ctrl`+`arrow keys` or by dragging a window to the edges of the screen.
 
 - **Tested on macOS**:
   - Tahoe

--- a/docs/mission-control/disable-tiling-animations.md
+++ b/docs/mission-control/disable-tiling-animations.md
@@ -1,0 +1,47 @@
+---
+title: Disable window tiling animations | Mission Control
+description: Disable the animation used when tiling windows.
+head:
+  - - meta
+    - property: 'og:title'
+      content: macOS defaults > Mission Control > Disable window tiling animations
+  - - meta
+    - property: 'og:description'
+      content: Disable the animation used when tiling windows.
+---
+
+# Disable window tiling animations
+
+Disable the animation used when tiling windows (triggered by `fn`+`ctrl`+`→ right`).
+
+- **Tested on macOS**:
+  - Tahoe
+- **Parameter type**: bool
+
+## Set to `true`
+
+Disable tiling animations.
+
+```bash
+defaults write com.apple.WindowManager "DisableTilingAnimations" -bool "true" && killall WindowManager
+```
+
+## Set to `false` (default value)
+
+Enable tiling animations.
+
+```bash
+defaults write com.apple.WindowManager "DisableTilingAnimations" -bool "false" && killall WindowManager
+```
+
+## Read current value
+
+```bash
+defaults read com.apple.WindowManager "DisableTilingAnimations"
+```
+
+## Reset to default value
+
+```bash
+defaults delete com.apple.WindowManager "DisableTilingAnimations" && killall WindowManager
+```


### PR DESCRIPTION
This PR adds documentation for the DisableTilingAnimations defaults key which turns off animations when snapping windows, either via mouse, or when using the keyboard shortcuts ( fn + ctrl + arrows ).